### PR TITLE
Sets client's consumer_cancel_notify capability

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -748,7 +748,9 @@ class Connection(AbstractChannel):
 
         """
         if self.server_capabilities.get('consumer_cancel_notify'):
-            client_properties['consumer_cancel_notify'] = True
+            if 'capabilities' not in client_properties:
+                client_properties['capabilities'] = {}
+            client_properties['capabilities']['consumer_cancel_notify'] = True
         args = AMQPWriter()
         args.write_table(client_properties)
         args.write_shortstr(mechanism)


### PR DESCRIPTION
consumer_cancel_notify needs to be set within the capabilities table
within the client-properties, rather than as a top level key.

Tested against RabbitMQ 2.8.4 on Erlang R14B02

http://www.rabbitmq.com/extensions.html#consumer-cancel-notify
| to enable this behaviour, the client must present a capabilities
| table in its client-properties in which there is a key
| consumer_cancel_notify and a boolean value true. See the capabilities
| section for further details on this.
