### PR TITLE
Set FD_CLOEXEC on opened sockets.

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -22,6 +22,7 @@ Read/Write AMQP frames over network transports.
 from __future__ import absolute_import
 
 import errno
+import fcntl
 import re
 import socket
 
@@ -99,6 +100,7 @@ class _AbstractTransport(object):
             # Didn't connect, return the most recent error message
             raise socket.error(last_err)
 
+        fcntl.fcntl(self.sock, fcntl.F_SETFD, fcntl.fcntl(self.sock, fcntl.F_GETFD) | fcntl.FD_CLOEXEC)
         self.sock.settimeout(None)
         self.sock.setsockopt(SOL_TCP, socket.TCP_NODELAY, 1)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)


### PR DESCRIPTION
Since py-amqp doesn't support resuming operation from just a
file descriptor, there is no use in leaving it open after execve(2).
