### PR TITLE
Fix autodoc ImportError bug

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -1,8 +1,9 @@
+import os
 import sys
 from paver.easy import *
 from paver import doctools
 from paver.setuputils import setup
-
+sys.path.insert(0, os.path.abspath('.'))
 PYCOMPILE_CACHES = ['*.pyc', '*$py.class']
 
 options(


### PR DESCRIPTION
When i use `paver html`  This error occurs:

```
$ paver html
---> pavement.html
---> pavement.clean_docs
rmtree docs/.build/html
---> paver.doctools.html
mkdir_p docs/.build
mkdir_p docs/.build/html
mkdir_p docs/.build/doctrees
sphinx-build  -b html -d docs/.build/doctrees docs/ docs/.build/html
Running Sphinx v1.2b1
loading pickled environment... not yet created
building [html]: targets for 13 source files that are out of date
updating environment: 13 added, 0 changed, 0 removed
reading sources... [100%] reference/index                                       
/home/dongwm/pa/docs/changelog.rst:147: WARNING: malformed hyperlink target.
/home/dongwm/pa/docs/reference/amqp.five.rst:9: WARNING: autodoc: failed to import module u'amqp.five'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/sphinx/ext/autodoc.py", line 326, in import_object
    __import__(self.modname)
ImportError: No module named five
/home/dongwm/pa/docs/reference/amqp.utils.rst:9: WARNING: autodoc: failed to import module u'amqp.utils'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/sphinx/ext/autodoc.py", line 326, in import_object
    __import__(self.modname)
ImportError: No module named utils

```

I found the reason: 

I have installed amqp of (1, 0, 13) version, it has not amqp.utils and amqp.five, but the process of generating docs first look for the system path, instead of the current directory, so I modified the pavement.py, the current directory on the first search location
