### PR TITLE
Ensure the channel is passed to the message

### DIFF
--- a/amqp/abstract_channel.py
+++ b/amqp/abstract_channel.py
@@ -92,7 +92,7 @@ class AbstractChannel(object):
         if content is None:
             return amqp_method(self, args)
         else:
-            content.channel = self
+            content.channel = self.channel_id
             return amqp_method(self, args, content)
 
     #: Placeholder, the concrete implementations will have to


### PR DESCRIPTION
A simple hack I've been running in production for awhile, all it does is ensure that message.channel gets populated with the proper channel_id
