### PR TITLE
Add address and port to socket error message for better troubleshooting.

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -92,7 +92,7 @@ class _AbstractTransport(object):
 
         if not self.sock:
             # Didn't connect, return the most recent error message
-            raise socket.error(last_err)
+            raise socket.error(last_err, 'Address: ' + host + ', Port: ' + str(port))
 
         try:
             self.sock.settimeout(None)


### PR DESCRIPTION
Add address and port to socket error message in AMQP/transport.py so that it's clearer what we've failed to connect to.

I've found this helpful in troubleshooting connections and misconfigurations.
