### PR TITLE
Creates a universal wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [nosetests]
 where = amqp/tests
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
The project supports Python 2 and Python 3, but the wheel package is Python 2
only. This change creates a universal wheel distribution compatible with both
platforms.
