### PR TITLE
AbstractTransport overwrites user defined timeout

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -95,7 +95,6 @@ class _AbstractTransport(object):
             raise socket.error(last_err)
 
         try:
-            self.sock.settimeout(None)
             self.sock.setsockopt(SOL_TCP, socket.TCP_NODELAY, 1)
             self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
 


### PR DESCRIPTION
Hello, the **AbstractTransport** is overwriting the user defined argument: **connect_timeout**, which leads to creating a socket with no timeout settings.