### PR TITLE
Adding ability to pass an ssl context to amqp ssl transport.

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -197,7 +197,12 @@ class SSLTransport(_AbstractTransport):
     def _setup_transport(self):
         """Wrap the socket in an SSL object."""
         if hasattr(self, 'sslopts'):
-            self.sock = ssl.wrap_socket(self.sock, **self.sslopts)
+            if 'context' in self.sslopts:
+                ctx = self.sslopts['context']
+                opts = {k:v for k, v in self.sslopts.items() if k != 'context'}
+                self.sock = ctx.wrap_socket(self.sock, **opts)
+            else:
+                self.sock = ssl.wrap_socket(self.sock, **self.sslopts)
         else:
             self.sock = ssl.wrap_socket(self.sock)
         self.sock.do_handshake()


### PR DESCRIPTION
Allows users to create a ssl context and pass that context to the AMQP SSL Transport layer.  This allows a user to set custom SSL options for the connection, such as whether they'd like the certificate's host name to be verified, and whether a certificate is required or not.

    -  Allows passing a 'context' attribute to the amqp transport, to override the default context
    -  If context is not present, falls back to normal functionality of using ssl.wrap_socket()