### PR TITLE
Add option to check host name in amqp ssl transport.

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -197,7 +197,13 @@ class SSLTransport(_AbstractTransport):
     def _setup_transport(self):
         """Wrap the socket in an SSL object."""
         if hasattr(self, 'sslopts'):
-            self.sock = ssl.wrap_socket(self.sock, **self.sslopts)
+            if 'context' in self.sslopts:
+                ctx_options = self.sslopts['context']
+                ctx = ssl.create_default_context(**{k:v for k,v in ctx_options.items() if k != 'check_hostname'})
+                ctx.check_hostname = ctx_options.get('check_hostname', False)
+                self.sock = ctx.wrap_socket(self.sock, **{k:v for k,v in self.sslopts.items() if k != 'context'})
+            else:
+                self.sock = ssl.wrap_socket(self.sock, **self.sslopts)
         else:
             self.sock = ssl.wrap_socket(self.sock)
         self.sock.do_handshake()


### PR DESCRIPTION
Allows users to create a default ssl context and pass options to that context in the AMQP SSL Transport layer.  This allows a user to set custom SSL options for the AMQP connection, such as whether they'd like the certificate's host name to be verified, and whether a certificate is required or not.

    -  Allows passing a 'context' attribute to the amqp transport, to override settings for SSL.wrap_socket()
    -  If context is not present, falls back to normal functionality of using ssl.wrap_socket()