### PR TITLE
Reset self.channels to emtpy dict instead of None when closing connection.

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -333,7 +333,8 @@ class Connection(AbstractChannel):
         except socket.error:
             pass  # connection already closed on the other end
         finally:
-            self.transport = self.connection = self.channels = None
+            self.transport = self.connection = None
+            self.channels = {}
 
     def _get_free_channel_id(self):
         try:


### PR DESCRIPTION
1. The initial value of self.channels is {}, not None.

2. After Connection.close() was invoked, if self.channels set to None,
invoking Connection.channel() will raise unexpected error.

In such case:

    try:
        return self.channels[channel_id]
    except KeyError:
        return self.Channel(self, channel_id, on_open=callback)

code above will raise `TypeError: 'NoneType' object has no attribute '__getitem__'`,
which will not got cought.

Signed-off-by: apporc <appleorchard2000@gmail.com>