### PR TITLE
Add 'nowait' to Connection.close(), buffer incoming data

### DIFF
--- a/amqp/abstract_channel.py
+++ b/amqp/abstract_channel.py
@@ -52,7 +52,7 @@ class AbstractChannel(object):
 
     def send_method(self, sig,
                     format=None, args=None, content=None,
-                    wait=None, callback=None):
+                    wait=None, callback=None, returns_tuple=False):
         p = promise()
         conn = self.connection
         if conn is None:
@@ -68,7 +68,7 @@ class AbstractChannel(object):
             p.then(callback)
         p()
         if wait:
-            return self.wait(wait)
+            return self.wait(wait, returns_tuple=returns_tuple)
         return p
 
     def close(self):

--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -116,7 +116,6 @@ class Channel(AbstractChannel):
 
         self.is_open = False
         self.active = True  # Flow control
-        self.returned_messages = Queue()
         self.callbacks = {}
         self.cancel_callbacks = {}
         self.auto_decode = auto_decode
@@ -1654,8 +1653,8 @@ class Channel(AbstractChannel):
         """
         return self.send_method(
             spec.Basic.Get, argsig, (0, queue, no_ack),
-            wait=spec.Basic.GetOk,
-        )
+            wait=spec.Basic.GetOk, returns_tuple=True
+        )[5]
 
     def _get_to_message(self, delivery_tag, redelivered, exchange, routing_key,
                         message_count, msg):

--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -79,7 +79,6 @@ class Channel(AbstractChannel):
         spec.method(spec.Basic.CancelOk, 's'),
         spec.method(spec.Basic.ConsumeOk, 's'),
         spec.method(spec.Basic.Deliver, 'sLbss', content=True),
-        spec.method(spec.Basic.GetEmpty, 's'),
         spec.method(spec.Basic.GetOk, 'Lbssl', content=True),
         spec.method(spec.Basic.QosOk),
         spec.method(spec.Basic.RecoverOk),

--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -277,9 +277,18 @@ class Channel(AbstractChannel):
 
         self.send_method(spec.Channel.CloseOk)
         self._do_revive()
-        raise error_for_code(
-            reply_code, reply_text, (class_id, method_id), ChannelError,
-        )
+        err = error_for_code(reply_code, reply_text, (class_id, method_id), ChannelError)
+        try:
+            if method_id%10 == 0:
+                method_id += 1
+                if (class_id,method_id) == (40,41)
+                    method_id = 51
+                    ## UnbindOk seems to violate the pattern
+            m = self._pending[(class_id, method_id)].popleft()
+        except IndexError:
+            raise err
+        else:
+            m.throw(err)
 
     def _on_close_ok(self):
         """Confirm a channel close
@@ -1164,6 +1173,7 @@ class Channel(AbstractChannel):
             consumer count
 
         """
+        if not arguments: arguments = {'Foo':'bar'}
         res = self.send_method(
             spec.Queue.Declare, argsig,
             (0, queue, passive, durable, exclusive, auto_delete,

--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -281,7 +281,7 @@ class Channel(AbstractChannel):
         try:
             if method_id%10 == 0:
                 method_id += 1
-                if (class_id,method_id) == (40,41)
+                if (class_id,method_id) == (40,41):
                     method_id = 51
                     ## UnbindOk seems to violate the pattern
             m = self._pending[(class_id, method_id)].popleft()

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -42,6 +42,7 @@ from .method_framing import frame_handler, frame_writer
 from .promise import ensure_promise
 from .serialization import _write_table
 from .transport import create_transport
+from .utils import FakeLock
 
 START_DEBUG_FMT = """
 Start from server, version: %d.%d, properties: %s, mechanisms: %s, locales: %s
@@ -145,7 +146,7 @@ class Connection(AbstractChannel):
                  frame_max=None, heartbeat=0, on_open=None, on_blocked=None,
                  on_unblocked=None, confirm_publish=False,
                  on_tune_ok=None, read_timeout=None, write_timeout=None,
-                 socket_settings=None, **kwargs):
+                 socket_settings=None, lock_factory=None, **kwargs):
         """Create a connection to the specified host, which should be
         a 'host[:port]', such as 'localhost', or '1.2.3.4:5672'
         (defaults to 'localhost', if a port is not specified then
@@ -160,6 +161,10 @@ class Connection(AbstractChannel):
 
         The 'socket_settings" parameter is a dictionary defining tcp
         settings which will be applied as socket options.
+        
+        'lock_factory' is a class that will be used to prevent conflicting
+        accesses to a connection or its channels. If None, no locking will
+        be performed.
 
         """
         self._connection_id = uuid.uuid4().hex
@@ -182,6 +187,7 @@ class Connection(AbstractChannel):
         self.locale = locale
         self.virtual_host = virtual_host
         self.on_tune_ok = ensure_promise(on_tune_ok)
+        self.make_lock = lock_factory or FakeLock
 
         self._handshake_complete = False
 

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -220,7 +220,7 @@ class Connection(AbstractChannel):
             socket_settings=socket_settings,
         )
         self.on_inbound_frame = frame_handler(self, self.on_inbound_method)
-        self._frame_writer = frame_writer(self, self.transport)
+        self._frame_writer = frame_writer(self)
 
         self.connect_timeout = connect_timeout
         self.connect()

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -404,7 +404,7 @@ class Connection(AbstractChannel):
             return self.method_reader.read_method()
 
     def close(self, reply_code=0, reply_text='', method_sig=(0, 0),
-              argsig='BssBB'):
+              nowait=False, argsig='BssBB'):
 
         """Request a connection close
 
@@ -458,6 +458,14 @@ class Connection(AbstractChannel):
                 When the close is provoked by a method exception, this
                 is the ID of the method.
 
+            nowait: boolean
+
+                do not wait for the reply method
+
+                If set, the client will not wait for a reply method.
+                The server's reply should be processed by calling
+                drain_events().
+
         """
         if self.transport is None:
             # already closed
@@ -466,7 +474,7 @@ class Connection(AbstractChannel):
         return self.send_method(
             spec.Connection.Close, argsig,
             (reply_code, reply_text, method_sig[0], method_sig[1]),
-            wait=spec.Connection.CloseOk,
+            wait=(None if nowait else spec.Connection.CloseOk),
         )
 
     def _on_close(self, reply_code, reply_text, class_id, method_id):

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -404,7 +404,7 @@ class Connection(AbstractChannel):
             return self.method_reader.read_method()
 
     def close(self, reply_code=0, reply_text='', method_sig=(0, 0),
-              nowait=False, argsig='BssBB'):
+              nowait=False, argsig='BsBB'):
 
         """Request a connection close
 

--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -24,7 +24,7 @@ from struct import pack, unpack_from, pack_into
 from . import spec
 from .basic_message import Message
 from .exceptions import UnexpectedFrame
-from .five import range
+from .five import range, string
 from .utils import coro, str_to_bytes
 
 __all__ = ['frame_handler', 'frame_writer']
@@ -126,7 +126,7 @@ def frame_writer(connection, transport,
             write(pack('>BHI%dsB' % framelen,
                        type_, channel, framelen, frame, 0xce))
             if body:
-                properties = content._serialize_properties()
+                properties = content._serialize_properties(isinstance(body,string))
                 frame = b''.join([
                     pack('>HHQ', method_sig[0], 0, len(body)),
                     properties,
@@ -144,14 +144,14 @@ def frame_writer(connection, transport,
 
         else:
             # ## FAST: pack into buffer and single write
-            frame = (''.join([pack('>HH', *method_sig), args])
-                     if type_ == 1 else '')
+            frame = (b''.join([pack('>HH', *method_sig), str_to_bytes(args)])
+                     if type_ == 1 else b'')
             framelen = len(frame)
             pack_into('>BHI%dsB' % framelen, buf, offset,
                       type_, channel, framelen, frame, 0xce)
             offset += 8 + framelen
             if body:
-                properties = content._serialize_properties()
+                properties = content._serialize_properties(isinstance(body,string))
                 frame = b''.join([
                     pack('>HHQ', method_sig[0], 0, len(body)),
                     properties,

--- a/amqp/promise.py
+++ b/amqp/promise.py
@@ -216,6 +216,10 @@ class promise(object):
                     *(self.args + args if args else self.args),
                     **(dict(self.kwargs, **kwargs) if kwargs else self.kwargs)
                 )
+                if isinstance(retval, promise):
+                    self.fun = None
+                    retval.then(self)
+                    return retval
                 self.value = (ca, ck) = (retval,), {}
             except Exception:
                 return self.set_error_state()

--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -522,7 +522,7 @@ class GenericContent(object):
         self.properties = props
         return offset
 
-    def _serialize_properties(self):
+    def _serialize_properties(self, set_utf8=True):
         """serialize the 'properties' attribute (a dictionary) into
         the raw bytes making up a set of property flags and a
         property list, suitable for putting into a content frame header."""
@@ -531,7 +531,8 @@ class GenericContent(object):
         flags = []
         sformat, svalues = [], []
         props = self.properties
-        props.setdefault('content_encoding', 'utf-8')
+        if set_utf8:
+            props.setdefault('content_encoding', 'utf-8')
         for key, proptype in self.PROPERTIES:
             val = props.get(key, None)
             if val is not None:

--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -27,6 +27,7 @@ from datetime import datetime
 from decimal import Decimal
 from io import BytesIO
 from struct import pack, unpack_from
+from struct import error as FrameDataError
 from time import mktime
 
 from . import spec
@@ -176,12 +177,12 @@ def loads(format, buf, offset=0,
     for p in format:
         if p == 'b':
             if not bitcount:
-                bits = ord(buf[offset:offset + 1])
-            bitcount = 8
+                bits = ord(buf[offset:offset+1])
+                bitcount = 8
+                offset += 1
             val = (bits & 1) == 1
             bits >>= 1
             bitcount -= 1
-            offset += 1
         elif p == 'o':
             bitcount = bits = 0
             val, = unpack_from('>B', buf, offset)
@@ -562,7 +563,7 @@ class GenericContent(object):
     def __eq__(self, other):
         if self.properties != getattr(other, 'properties', {}):
             return False
-        if self.body != getattr(other, 'body', ''):
+        if getattr(self, 'body', '') != getattr(other, 'body', ''):
             return False
         return True
 

--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -21,7 +21,6 @@ Convert between bytestreams and higher-level AMQP types.
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 from __future__ import absolute_import
 
-import calendar
 import sys
 
 from datetime import datetime
@@ -122,7 +121,7 @@ def _read_item(buf, offset=0, unpack_from=unpack_from, ftype_t=ftype_t):
         while offset < limit:
             keylen, = unpack_from('>B', buf, offset)
             offset += 1
-            key = buf[offset:offset + keylen]
+            key = pstr_t(buf[offset:offset + keylen])
             offset += keylen
             val[key], offset = _read_item(buf, offset)
     # 'A': array
@@ -143,7 +142,7 @@ def _read_item(buf, offset=0, unpack_from=unpack_from, ftype_t=ftype_t):
     elif ftype == 'T':
         val, = unpack_from('>Q', buf, offset)
         offset += 8
-        val = datetime.utcfromtimestamp(val)
+        val = datetime.fromtimestamp(val)
     # 'V': void
     elif ftype == 'V':
         val = None
@@ -240,7 +239,7 @@ def loads(format, buf, offset=0,
             bitcount = bits = 0
             val, = unpack_from('>Q', buf, offset)
             offset += 8
-            val = datetime.utcfromtimestamp(val)
+            val = datetime.fromtimestamp(val)
         append(val)
     return values, offset
 
@@ -373,9 +372,13 @@ def _write_item(v, write, bits, pack=pack,
             v = (v * 10) + d
         if sign:
             v = -v
-        write('>cBi', b'D', -exponent, v)
+        write(pack('>cBi', b'D', -exponent, v))
     elif isinstance(v, datetime):
-        write(pack('>cQ', b'T', long_t(calendar.timegm(v.utctimetuple()))))
+        if IS_PY3:
+            timestamp = int(v.timestamp())
+        else:
+            timestamp = int(v.strftime("%s"))
+        write(pack('>cQ', b'T', timestamp))
     elif isinstance(v, dict):
         write(b'F')
         _write_table(v, write, bits)
@@ -448,7 +451,8 @@ def decode_properties_basic(buf, offset=0,
         properties['message_id'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0040:
-        properties['timestamp'], = unpack_from('>Q', buf, offset)
+        val, = unpack_from('>Q', buf, offset)
+        properties['timestamp'] = datetime.fromtimestamp(val)
         offset += 8
     if flags & 0x0020:
         slen, = unpack_from('>B', buf, offset)
@@ -554,6 +558,13 @@ class GenericContent(object):
             write(pack('>H', flag_bits))
         write(dumps(''.join(sformat), svalues))
         return result.getvalue()
+
+    def __eq__(self, other):
+        if self.properties != getattr(other, 'properties', {}):
+            return False
+        if self.body != getattr(other, 'body', ''):
+            return False
+        return True
 
     def inbound_header(self, buf, offset=0):
         class_id, self.body_size = unpack_from('>HxxQ', buf, offset)

--- a/amqp/spec.py
+++ b/amqp/spec.py
@@ -79,7 +79,6 @@ class Basic:
     Deliver = (60, 60)
     Get = (60, 70)
     GetOk = (60, 71)
-    GetEmpty = (60, 80)
     Ack = (60, 80)
     Nack = (60, 120)
     Reject = (60, 90)

--- a/amqp/tests/test_promise.py
+++ b/amqp/tests/test_promise.py
@@ -263,3 +263,18 @@ class test_promise(Case):
         d = promise(Mock(name='d'), on_error=de)
         p2.then(d)
         de.fun.assert_called_with(exc)
+
+    def test_promise_func(self):
+        def incr(x):
+            return x + 1
+        a = promise(Mock(name='a', side_effect=incr))
+        def pfun(*x):
+            return a
+        b = promise(pfun)
+        mc = Mock(name='c')
+        b.then(mc)
+        b()
+        mc.assert_not_called()
+        a(42)
+        mc.assert_called_with(43)
+

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -273,7 +273,7 @@ class SSLTransport(_AbstractTransport):
         try:
             while len(rbuf) < n:
                 try:
-                    s = recv(n - len(rbuf))  # see note above
+                    s = recv(max(32768,n - len(rbuf)))
                 except socket.error as exc:
                     # ssl.sock.read may cause ENOENT if the
                     # operation couldn't be performed (Issue celery#1414).
@@ -326,7 +326,7 @@ class TCPTransport(_AbstractTransport):
         try:
             while len(rbuf) < n:
                 try:
-                    s = recv(n - len(rbuf))
+                    s = recv(max(32768,n - len(rbuf)))
                 except socket.error as exc:
                     if not initial and exc.errno in _errnos:
                         continue

--- a/amqp/utils.py
+++ b/amqp/utils.py
@@ -77,3 +77,22 @@ else:
 
     def bytes_to_str(s):                # noqa
         return s
+
+fake_lock = None
+class FakeLock(object):
+    """This is a lock which does nothing.
+    Since it has no state, it's a Singleton."""
+    def __new__(cls):
+        global fake_lock
+        if fake_lock is None:
+            fake_lock = super(FakeLock,cls).__new__(cls)
+        return fake_lock
+    def __enter__(self):
+        pass
+    def __exit__(self, a,b,c):
+        pass
+    def acquire(self, nowait=False):
+        return True
+    def release(self):
+        pass
+

--- a/funtests/run_all.py
+++ b/funtests/run_all.py
@@ -22,7 +22,7 @@ import settings
 
 TEST_NAMES = [
     'test_exceptions',
-#    'test_serialization',
+    'test_serialization',
     'test_basic_message',
     'test_connection',
     'test_channel',

--- a/funtests/run_all.py
+++ b/funtests/run_all.py
@@ -22,7 +22,7 @@ import settings
 
 TEST_NAMES = [
     'test_exceptions',
-    'test_serialization',
+#    'test_serialization',
     'test_basic_message',
     'test_connection',
     'test_channel',

--- a/funtests/settings.py
+++ b/funtests/settings.py
@@ -36,6 +36,11 @@ def parse_args():
         default='localhost',
     )
     parser.add_option(
+        '-V', '--vhost', dest='vhost',
+        help='virtual host to use (default: %default)',
+        default='/',
+    )
+    parser.add_option(
         '-u', '--userid', dest='userid',
         help='userid to authenticate as (default: %default)',
         default='guest',
@@ -84,6 +89,7 @@ def parse_args():
     connect_args['userid'] = options.userid
     connect_args['password'] = options.password
     connect_args['ssl'] = options.ssl
+    connect_args['virtual_host'] = options.vhost
 
     if options.verbose:
         test_args['verbosity'] = 2

--- a/funtests/test_basic_message.py
+++ b/funtests/test_basic_message.py
@@ -33,6 +33,7 @@ except ImportError:
 import settings
 
 from amqp.basic_message import Message
+from amqp import spec
 
 
 class TestBasicMessage(unittest.TestCase):
@@ -42,7 +43,7 @@ class TestBasicMessage(unittest.TestCase):
         raw_properties = msg._serialize_properties()
 
         new_msg = Message()
-        new_msg._load_properties(raw_properties)
+        new_msg._load_properties(spec.Basic.CLASS_ID, raw_properties)
         new_msg.body = msg.body
 
         self.assertEqual(msg, new_msg)

--- a/funtests/test_channel.py
+++ b/funtests/test_channel.py
@@ -186,7 +186,7 @@ class TestChannel(unittest.TestCase):
             self.ch.queue_delete('bogus_queue_that_does_not_exist')
         )
 
-    def xtest_survives_channel_error(self):
+    def test_survives_channel_error(self):
         with self.assertRaises(ChannelError):
             self.ch.queue_declare('krjqheewq_bogus', passive=True)
         self.ch.queue_declare('funtest_survive')

--- a/funtests/test_channel.py
+++ b/funtests/test_channel.py
@@ -57,10 +57,10 @@ class TestChannel(unittest.TestCase):
         msg2 = self.ch.basic_get(no_ack=True)
         self.assertEqual(msg, msg2)
 
-        n = self.ch.queue_purge()
+        n = self.ch.queue_purge().value[0][0]
         self.assertEqual(n, 0)
 
-        n = self.ch.queue_delete()
+        n = self.ch.queue_delete().value[0][0]
         self.assertEqual(n, 0)
 
     def test_encoding(self):
@@ -159,7 +159,7 @@ class TestChannel(unittest.TestCase):
 
     def test_queue_delete_empty(self):
         self.assertFalse(
-            self.ch.queue_delete('bogus_queue_that_does_not_exist')
+            self.ch.queue_delete('bogus_queue_that_does_not_exist').value[0][0]
         )
 
     def xtest_survives_channel_error(self):

--- a/funtests/test_channel.py
+++ b/funtests/test_channel.py
@@ -57,10 +57,34 @@ class TestChannel(unittest.TestCase):
         msg2 = self.ch.basic_get(no_ack=True)
         self.assertEqual(msg, msg2)
 
-        n = self.ch.queue_purge().value[0][0]
+        n = self.ch.queue_purge()
         self.assertEqual(n, 0)
 
-        n = self.ch.queue_delete().value[0][0]
+        n = self.ch.queue_delete()
+        self.assertEqual(n, 0)
+
+    def test_defaults_confirmed(self):
+        """Same as test_defaults but with two confirmed messages"""
+        msg = Message(
+            'funtest message',
+            content_type='text/plain',
+            application_headers={'foo': 7, 'bar': 'baz'},
+        )
+
+        qname, _, _ = self.ch.queue_declare()
+        self.ch.basic_publish_confirm(msg, routing_key=qname)
+        self.ch.basic_publish_confirm(msg, routing_key=qname)
+
+        msg2 = self.ch.basic_get(no_ack=True)
+        self.assertEqual(msg, msg2)
+
+        msg3 = self.ch.basic_get(no_ack=True)
+        self.assertEqual(msg, msg3)
+
+        n = self.ch.queue_purge()
+        self.assertEqual(n, 0)
+
+        n = self.ch.queue_delete()
         self.assertEqual(n, 0)
 
     def test_encoding(self):
@@ -159,7 +183,7 @@ class TestChannel(unittest.TestCase):
 
     def test_queue_delete_empty(self):
         self.assertFalse(
-            self.ch.queue_delete('bogus_queue_that_does_not_exist').value[0][0]
+            self.ch.queue_delete('bogus_queue_that_does_not_exist')
         )
 
     def xtest_survives_channel_error(self):

--- a/funtests/test_channel.py
+++ b/funtests/test_channel.py
@@ -25,6 +25,8 @@ import unittest
 import settings
 
 from amqp import ChannelError, Connection, Message, FrameSyntaxError
+from amqp.five import string
+from amqp.utils import str_to_bytes
 
 
 class TestChannel(unittest.TestCase):
@@ -74,8 +76,8 @@ class TestChannel(unittest.TestCase):
         self.ch.basic_publish(msg, 'amq.direct', routing_key=my_routing_key)
         msg2 = self.ch.basic_get(qname, no_ack=True)
         self.assertFalse(hasattr(msg2, 'content_encoding'))
-        self.assertTrue(isinstance(msg2.body, str))
-        self.assertEqual(msg2.body, 'hello world')
+        self.assertTrue(isinstance(msg2.body, bytes))
+        self.assertEqual(msg2.body, str_to_bytes('hello world'))
 
         #
         # Default UTF-8 encoding of unicode body, returned as unicode
@@ -83,8 +85,8 @@ class TestChannel(unittest.TestCase):
         msg = Message(u'hello world')
         self.ch.basic_publish(msg, 'amq.direct', routing_key=my_routing_key)
         msg2 = self.ch.basic_get(qname, no_ack=True)
-        self.assertEqual(msg2.content_encoding, 'UTF-8')
-        self.assertTrue(isinstance(msg2.body, unicode))
+        self.assertEqual(msg2.content_encoding.upper(), 'UTF-8')
+        self.assertTrue(isinstance(msg2.body, string))
         self.assertEqual(msg2.body, u'hello world')
 
         #
@@ -94,7 +96,7 @@ class TestChannel(unittest.TestCase):
         self.ch.basic_publish(msg, 'amq.direct', routing_key=my_routing_key)
         msg2 = self.ch.basic_get(qname, no_ack=True)
         self.assertEqual(msg2.content_encoding, 'latin_1')
-        self.assertTrue(isinstance(msg2.body, unicode))
+        self.assertTrue(isinstance(msg2.body, string))
         self.assertEqual(msg2.body, u'hello world')
 
         #
@@ -104,7 +106,7 @@ class TestChannel(unittest.TestCase):
         self.ch.basic_publish(msg, 'amq.direct', routing_key=my_routing_key)
         msg2 = self.ch.basic_get(qname, no_ack=True)
         self.assertEqual(msg2.content_encoding, 'latin_1')
-        self.assertTrue(isinstance(msg2.body, unicode))
+        self.assertTrue(isinstance(msg2.body, string))
         self.assertEqual(msg2.body, u'hello w\u00f6rld')
 
         #
@@ -131,7 +133,7 @@ class TestChannel(unittest.TestCase):
         msg = Message(u'hello w\u00f6rld')
         self.ch.basic_publish(msg, 'amq.direct', routing_key=my_routing_key)
         msg2 = self.ch.basic_get(qname, no_ack=True)
-        self.assertEqual(msg2.content_encoding, 'UTF-8')
+        self.assertEqual(msg2.content_encoding.upper(), 'UTF-8')
         self.assertTrue(isinstance(msg2.body, bytes))
         self.assertEqual(msg2.body, u'hello w\xc3\xb6rld'.encode('latin_1'))
 


### PR DESCRIPTION
Buffering: calling read() for a few bytes is significantly more expensive than simply reading everything at once.

.close(): After setting up the channels, running drain_events() in a separate thread works quite well – except there's no way to cleanly close the connection.
