### PR TITLE
Missing versions in Changelog

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -38,6 +38,29 @@ http://code.google.com/p/py-amqplib/source/browse/CHANGES
 
     Contributed by Vic Kumar.
 
+.. _version-1.4.9:
+
+1.4.9
+=====
+:release-date: 2016-01-08 5:50 PM PST
+
+- Fixes compatibility with Linux/OS X instances where the ``ctypes`` module
+  does not exist.
+
+    Fix contributed by Jared Lewis.
+
+.. _version-1.4.8:
+
+1.4.8
+=====
+:release-date: 2015-12-07 12:25 AM
+:release-by: Ask Solem
+
+- ``abstract_channel.wait`` now accepts a float `timeout` parameter expressed
+    in seconds
+
+    Contributed by Goir.
+
 .. _version-1.4.7:
 
 1.4.7
@@ -58,7 +81,6 @@ http://code.google.com/p/py-amqplib/source/browse/CHANGES
 - Wheel package installation now supported by both Python 2 and Python3.
 
     Fix contributed by Rémy Greinhofer.
-
 
 .. _version-1.4.6:
 


### PR DESCRIPTION
Missing versions 1.4.8 and 1.4.9 is added to Changelog.