### PR TITLE
Change the re-raise comparison to be inclusive

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -152,7 +152,7 @@ class _AbstractTransport(object):
             except socket.error as exc:
                 self.sock.close()
                 self.sock = None
-                if i + 1 > len(entries):
+                if i + 1 >= len(entries):
                     raise
             else:
                 break


### PR DESCRIPTION
Currently when the connect function fails you get something like:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/site-packages/celery-4.0.0rc1-py2.7.egg/celery/app/task.py", line 376, in delay
    return self.apply_async(args, kwargs)
  File "/usr/lib/python2.7/site-packages/celery-4.0.0rc1-py2.7.egg/celery/app/task.py", line 503, in apply_async
    **options
  File "/usr/lib/python2.7/site-packages/celery-4.0.0rc1-py2.7.egg/celery/app/base.py", line 649, in send_task
    amqp.send_task_message(P, name, message, **options)
  File "/usr/lib/python2.7/site-packages/celery-4.0.0rc1-py2.7.egg/celery/app/amqp.py", line 550, in send_task_message
    **properties
  File "/usr/lib/python2.7/site-packages/kombu/messaging.py", line 180, in publish
    exchange_name, declare,
  File "/usr/lib/python2.7/site-packages/kombu/connection.py", line 443, in _ensured
    return fun(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/kombu/messaging.py", line 186, in _publish
    channel = self.channel
  File "/usr/lib/python2.7/site-packages/kombu/messaging.py", line 208, in _get_channel
    channel = self._channel = channel()
  File "/usr/lib/python2.7/site-packages/kombu/utils/__init__.py", line 401, in __call__
    value = self.__value__ = self.__contract__()
  File "/usr/lib/python2.7/site-packages/kombu/messaging.py", line 223, in <lambda>
    channel = ChannelPromise(lambda: connection.default_channel)
  File "/usr/lib/python2.7/site-packages/kombu/connection.py", line 764, in default_channel
    self.connection
  File "/usr/lib/python2.7/site-packages/kombu/connection.py", line 749, in connection
    self._connection = self._establish_connection()
  File "/usr/lib/python2.7/site-packages/kombu/connection.py", line 701, in _establish_connection
    conn = self.transport.establish_connection()
  File "/usr/lib/python2.7/site-packages/kombu/transport/pyamqp.py", line 125, in establish_connection
    conn.connect()
  File "/usr/lib/python2.7/site-packages/amqp/connection.py", line 262, in connect
    self.transport.connect()
  File "/usr/lib/python2.7/site-packages/amqp/transport.py", line 100, in connect
    self.socket_settings, self.read_timeout, self.write_timeout,
  File "/usr/lib/python2.7/site-packages/amqp/transport.py", line 165, in _init_socket
    self.sock.settimeout(None)  # set socket back to blocking mode
AttributeError: 'NoneType' object has no attribute 'settimeout'
```

Because the greater-than comparison can never be satisfied.