### PR TITLE
checked for one more version of librt.so

### DIFF
--- a/amqp/five.py
+++ b/amqp/five.py
@@ -97,7 +97,14 @@ if sys.version_info < (3, 3):
                 ('tv_nsec', ctypes.c_long),
             ]
 
-        librt = ctypes.CDLL('librt.so.1', use_errno=True)
+        try:
+            librt = ctypes.CDLL('librt.so.1', use_errno=True)
+        except:
+            try:
+                librt = ctypes.CDLL('librt.so.0', use_errno=True)
+            except:
+                raise OSError, "could not find librt in current system"
+
         clock_gettime = librt.clock_gettime
         clock_gettime.argtypes = [
             ctypes.c_int, ctypes.POINTER(timespec),


### PR DESCRIPTION
there was only check for one version of librt.so.x ... according to my case as im using this client in some embedded systems. i think there should be some other version checks too. like librt.so.0 (worked for me) ... or latest versions.