### PR TITLE
Fixed frame args packing in PY3

### DIFF
--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -138,7 +138,8 @@ def frame_writer(connection, transport,
 
         else:
             # ## FAST: pack into buffer and single write
-            frame = (b''.join([pack('>HH', *method_sig), args])
+            frame = (b''.join([pack('>HH', *method_sig), 
+                                    str_to_bytes(args)])
                      if type_ == 1 else b'')
             framelen = len(frame)
             pack_into('>BHI%dsB' % framelen, buf, offset,


### PR DESCRIPTION
Fixed frame args packing that used to raise a `TypeError` in PY3, fixes #83