### PR TITLE
Fixes issue #85: the module can be imported on python 2.7.3 running i…

### DIFF
--- a/amqp/__init__.py
+++ b/amqp/__init__.py
@@ -17,13 +17,6 @@
 from __future__ import absolute_import, unicode_literals
 
 from collections import namedtuple
-from vine import promise
-
-# Enable celery 3.1.23 to import the package instead of breaking on an
-# unknown symbol
-__all_externals__ = [
-    'promise',
-]
 
 version_info_t = namedtuple(
     'version_info_t', ('major', 'minor', 'micro', 'releaselevel', 'serial'),
@@ -75,6 +68,13 @@ from .exceptions import (               # noqa
     error_for_code,
     __all__ as _all_exceptions,
 )
+from .utils import promise              # noqa
+
+# Enable celery 3.1.23 to import the package instead of breaking on an
+# unknown symbol
+__all_externals__ = [
+    'promise',
+]
 
 __all__ = [
     'Connection',

--- a/amqp/__init__.py
+++ b/amqp/__init__.py
@@ -75,3 +75,12 @@ __all__ = [
     'Message',
 ]
 __all__ += _all_exceptions
+
+# Enable celery 3.1.23 to import the package instead of breaking on an unknown symbol
+from vine import promise
+
+__all_externals__ = [
+    'promise',
+]
+
+__all__ += __all_externals__

--- a/amqp/__init__.py
+++ b/amqp/__init__.py
@@ -17,6 +17,13 @@
 from __future__ import absolute_import, unicode_literals
 
 from collections import namedtuple
+from vine import promise
+
+# Enable celery 3.1.23 to import the package instead of breaking on an
+# unknown symbol
+__all_externals__ = [
+    'promise',
+]
 
 version_info_t = namedtuple(
     'version_info_t', ('major', 'minor', 'micro', 'releaselevel', 'serial'),
@@ -75,12 +82,5 @@ __all__ = [
     'Message',
 ]
 __all__ += _all_exceptions
-
-# Enable celery 3.1.23 to import the package instead of breaking on an unknown symbol
-from vine import promise
-
-__all_externals__ = [
-    'promise',
-]
 
 __all__ += __all_externals__

--- a/amqp/basic_message.py
+++ b/amqp/basic_message.py
@@ -26,8 +26,6 @@ from __future__ import absolute_import, unicode_literals
 # Source:
 #   http://stackoverflow.com/a/14216937/4982251
 from .spec import Basic
-
-from . import spec
 from .serialization import GenericContent
 
 __all__ = ['Message']

--- a/amqp/basic_message.py
+++ b/amqp/basic_message.py
@@ -16,6 +16,17 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 from __future__ import absolute_import, unicode_literals
 
+# Intended to fix #85: ImportError: cannot import name spec
+# Encountered on python 2.7.3
+# "The submodules often need to refer to each other. For example, the
+#  surround [sic] module might use the echo module. In fact, such
+#  references are so common that the import statement first looks in
+#  the containing package before looking in the standard module search
+#  path."
+# Source:
+#   http://stackoverflow.com/a/14216937/4982251
+from .spec import Basic
+
 from . import spec
 from .serialization import GenericContent
 
@@ -24,7 +35,7 @@ __all__ = ['Message']
 
 class Message(GenericContent):
     """A Message for use with the Channnel.basic_* methods."""
-    CLASS_ID = spec.Basic.CLASS_ID
+    CLASS_ID = Basic.CLASS_ID
 
     #: Instances of this class have these attributes, which
     #: are passed back and forth as message properties between

--- a/amqp/exceptions.py
+++ b/amqp/exceptions.py
@@ -254,4 +254,4 @@ METHOD_NAME_MAP = {
 
 
 for _method_id, _method_name in list(METHOD_NAME_MAP.items()):
-    METHOD_NAME_MAP[unpack('>I', pack('>HH', *_method_id))[0]] = _method_name
+    METHOD_NAME_MAP[unpack(str('>I'), pack(str('>HH'), *_method_id))[0]] = _method_name

--- a/amqp/exceptions.py
+++ b/amqp/exceptions.py
@@ -254,4 +254,5 @@ METHOD_NAME_MAP = {
 
 
 for _method_id, _method_name in list(METHOD_NAME_MAP.items()):
-    METHOD_NAME_MAP[unpack(str('>I'), pack(str('>HH'), *_method_id))[0]] = _method_name
+    METHOD_NAME_MAP[unpack(str('>I'), pack(str('>HH'), *_method_id))[0]] = \
+        _method_name

--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -30,7 +30,7 @@ from io import BytesIO
 from struct import pack, unpack_from
 from time import mktime
 
-from . import spec
+from .spec import Basic
 from .exceptions import FrameSyntaxError
 from .five import int_types, long_t, string, string_t, items
 from .utils import bytes_to_str as pstr_t, str_to_bytes
@@ -470,7 +470,7 @@ def decode_properties_basic(buf, offset=0,
     return properties, offset
 
 PROPERTY_CLASSES = {
-    spec.Basic.CLASS_ID: decode_properties_basic,
+    Basic.CLASS_ID: decode_properties_basic,
 }
 
 

--- a/amqp/utils.py
+++ b/amqp/utils.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, unicode_literals
 import logging
 import sys
 
+# enables celery 3.1.23 to start again
+from vine import promise                # noqa
 from vine.utils import wraps
 
 from .five import string_t


### PR DESCRIPTION
…n unicode mode. I guess sys.setdefaultencoding('utf-8') breaks the arguments to the pack