### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 |build-status| |coverage| |bitdeli|
 
 :Version: 2.0.0rc2
-:Web: http://amqp.readthedocs.org/
+:Web: https://amqp.readthedocs.io/
 :Download: http://pypi.python.org/pypi/amqp/
 :Source: http://github.com/celery/py-amqp/
 :Keywords: amqp, rabbitmq
@@ -21,7 +21,7 @@ This library should be API compatible with `librabbitmq`_.
 
 .. _amqplib: http://pypi.python.org/pypi/amqplib
 .. _Celery: http://celeryproject.org/
-.. _kombu: http://kombu.readthedocs.org/
+.. _kombu: https://kombu.readthedocs.io/
 .. _librabbitmq: http://pypi.python.org/pypi/librabbitmq
 
 Differences from `amqplib`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ globals().update(conf.build_config(
     description='Python Promises',
     version_dev='2.0',
     version_stable='1.4',
-    canonical_url='http://amqp.readthedocs.org',
+    canonical_url='https://amqp.readthedocs.io',
     webdomain='celeryproject.org',
     github_project='celery/py-amqp',
     author='Ask Solem & contributors',

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -1,5 +1,5 @@
 :Version: 2.0.0
-:Web: http://amqp.readthedocs.org/
+:Web: https://amqp.readthedocs.io/
 :Download: http://pypi.python.org/pypi/amqp/
 :Source: http://github.com/celery/py-amqp/
 :Keywords: amqp, rabbitmq
@@ -15,7 +15,7 @@ This library should be API compatible with `librabbitmq`_.
 
 .. _amqplib: http://pypi.python.org/pypi/amqplib
 .. _Celery: http://celeryproject.org/
-.. _kombu: http://kombu.readthedocs.org/
+.. _kombu: https://kombu.readthedocs.io/
 .. _librabbitmq: http://pypi.python.org/pypi/librabbitmq
 
 Differences from `amqplib`_


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.