### PR TITLE
Fix unicode literals (Python 2.7)

### DIFF
--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -117,7 +117,7 @@ def frame_writer(connection, transport,
                                str_to_bytes(args)])
                      if type_ == 1 else b'')  # encode method frame
             framelen = len(frame)
-            write(pack(b'>BHI%dsB' % framelen,
+            write(pack((u'>BHI%dsB' % framelen).encode(),
                        type_, channel, framelen, frame, 0xce))
             if body:
                 properties = content._serialize_properties()
@@ -126,13 +126,13 @@ def frame_writer(connection, transport,
                     properties,
                 ])
                 framelen = len(frame)
-                write(pack(b'>BHI%dsB' % framelen,
+                write(pack((u'>BHI%dsB' % framelen).encode(),
                            2, channel, framelen, frame, 0xce))
 
                 for i in range(0, bodylen, chunk_size):
                     frame = body[i:i + chunk_size]
                     framelen = len(frame)
-                    write(pack(b'>BHI%dsB' % framelen,
+                    write(pack((u'>BHI%dsB' % framelen).encode(),
                                3, channel, framelen,
                                str_to_bytes(frame), 0xce))
 
@@ -142,7 +142,7 @@ def frame_writer(connection, transport,
                                str_to_bytes(args)])
                      if type_ == 1 else b'')
             framelen = len(frame)
-            pack_into(b'>BHI%dsB' % framelen, buf, offset,
+            pack_into((u'>BHI%dsB' % framelen).encode(), buf, offset,
                       type_, channel, framelen, frame, 0xce)
             offset += 8 + framelen
             if body:
@@ -153,12 +153,12 @@ def frame_writer(connection, transport,
                 ])
                 framelen = len(frame)
 
-                pack_into(b'>BHI%dsB' % framelen, buf, offset,
+                pack_into((u'>BHI%dsB' % framelen).encode(), buf, offset,
                           2, channel, framelen, frame, 0xce)
                 offset += 8 + framelen
 
                 framelen = len(body)
-                pack_into(b'>BHI%dsB' % framelen, buf, offset,
+                pack_into((u'>BHI%dsB' % framelen).encode(), buf, offset,
                           3, channel, framelen, str_to_bytes(body), 0xce)
                 offset += 8 + framelen
 

--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from collections import defaultdict
 from struct import pack, unpack_from, pack_into
@@ -113,52 +113,52 @@ def frame_writer(connection, transport,
 
         if bigbody:
             # ## SLOW: string copy and write for every frame
-            frame = (b''.join([pack('>HH', *method_sig),
+            frame = (b''.join([pack(b'>HH', *method_sig),
                                str_to_bytes(args)])
                      if type_ == 1 else b'')  # encode method frame
             framelen = len(frame)
-            write(pack('>BHI%dsB' % framelen,
+            write(pack(b'>BHI%dsB' % framelen,
                        type_, channel, framelen, frame, 0xce))
             if body:
                 properties = content._serialize_properties()
                 frame = b''.join([
-                    pack('>HHQ', method_sig[0], 0, len(body)),
+                    pack(b'>HHQ', method_sig[0], 0, len(body)),
                     properties,
                 ])
                 framelen = len(frame)
-                write(pack('>BHI%dsB' % framelen,
+                write(pack(b'>BHI%dsB' % framelen,
                            2, channel, framelen, frame, 0xce))
 
                 for i in range(0, bodylen, chunk_size):
                     frame = body[i:i + chunk_size]
                     framelen = len(frame)
-                    write(pack('>BHI%dsB' % framelen,
+                    write(pack(b'>BHI%dsB' % framelen,
                                3, channel, framelen,
                                str_to_bytes(frame), 0xce))
 
         else:
             # ## FAST: pack into buffer and single write
-            frame = (b''.join([pack('>HH', *method_sig),
+            frame = (b''.join([pack(b'>HH', *method_sig),
                                str_to_bytes(args)])
                      if type_ == 1 else b'')
             framelen = len(frame)
-            pack_into('>BHI%dsB' % framelen, buf, offset,
+            pack_into(b'>BHI%dsB' % framelen, buf, offset,
                       type_, channel, framelen, frame, 0xce)
             offset += 8 + framelen
             if body:
                 properties = content._serialize_properties()
                 frame = b''.join([
-                    pack('>HHQ', method_sig[0], 0, len(body)),
+                    pack(b'>HHQ', method_sig[0], 0, len(body)),
                     properties,
                 ])
                 framelen = len(frame)
 
-                pack_into('>BHI%dsB' % framelen, buf, offset,
+                pack_into(b'>BHI%dsB' % framelen, buf, offset,
                           2, channel, framelen, frame, 0xce)
                 offset += 8 + framelen
 
                 framelen = len(body)
-                pack_into('>BHI%dsB' % framelen, buf, offset,
+                pack_into(b'>BHI%dsB' % framelen, buf, offset,
                           3, channel, framelen, str_to_bytes(body), 0xce)
                 offset += 8 + framelen
 

--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 from collections import defaultdict
 from struct import pack, unpack_from, pack_into

--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -19,7 +19,7 @@ Convert between bytestreams and higher-level AMQP types.
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 import calendar
 import sys

--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -19,7 +19,7 @@ Convert between bytestreams and higher-level AMQP types.
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import calendar
 import sys
@@ -56,78 +56,78 @@ def _read_item(buf, offset=0, unpack_from=unpack_from, ftype_t=ftype_t):
 
     # 'S': long string
     if ftype == 'S':
-        slen, = unpack_from('>I', buf, offset)
+        slen, = unpack_from(b'>I', buf, offset)
         offset += 4
         val = pstr_t(buf[offset:offset + slen])
         offset += slen
     # 's': short string
     elif ftype == 's':
-        slen, = unpack_from('>B', buf, offset)
+        slen, = unpack_from(b'>B', buf, offset)
         offset += 1
         val = pstr_t(buf[offset:offset + slen])
         offset += slen
     # 'b': short-short int
     elif ftype == 'b':
-        val, = unpack_from('>B', buf, offset)
+        val, = unpack_from(b'>B', buf, offset)
         offset += 1
     # 'B': short-short unsigned int
     elif ftype == 'B':
-        val, = unpack_from('>b', buf, offset)
+        val, = unpack_from(b'>b', buf, offset)
         offset += 1
     # 'U': short int
     elif ftype == 'U':
-        val, = unpack_from('>h', buf, offset)
+        val, = unpack_from(b'>h', buf, offset)
         offset += 2
     # 'u': short unsigned int
     elif ftype == 'u':
-        val, = unpack_from('>H', buf, offset)
+        val, = unpack_from(b'>H', buf, offset)
         offset += 2
     # 'I': long int
     elif ftype == 'I':
-        val, = unpack_from('>i', buf, offset)
+        val, = unpack_from(b'>i', buf, offset)
         offset += 4
     # 'i': long unsigned int
     elif ftype == 'i':
-        val, = unpack_from('>I', buf, offset)
+        val, = unpack_from(b'>I', buf, offset)
         offset += 4
     # 'L': long long int
     elif ftype == 'L':
-        val, = unpack_from('>q', buf, offset)
+        val, = unpack_from(b'>q', buf, offset)
         offset += 8
     # 'l': long long unsigned int
     elif ftype == 'l':
-        val, = unpack_from('>Q', buf, offset)
+        val, = unpack_from(b'>Q', buf, offset)
         offset += 8
     # 'f': float
     elif ftype == 'f':
-        val, = unpack_from('>f', buf, offset)
+        val, = unpack_from(b'>f', buf, offset)
         offset += 4
     # 'd': double
     elif ftype == 'd':
-        val, = unpack_from('>d', buf, offset)
+        val, = unpack_from(b'>d', buf, offset)
         offset += 8
     # 'D': decimal
     elif ftype == 'D':
-        d, = unpack_from('>B', buf, offset)
+        d, = unpack_from(b'>B', buf, offset)
         offset += 1
-        n, = unpack_from('>i', buf, offset)
+        n, = unpack_from(b'>i', buf, offset)
         offset += 4
         val = Decimal(n) / Decimal(10 ** d)
     # 'F': table
     elif ftype == 'F':
-        tlen, = unpack_from('>I', buf, offset)
+        tlen, = unpack_from(b'>I', buf, offset)
         offset += 4
         limit = offset + tlen
         val = {}
         while offset < limit:
-            keylen, = unpack_from('>B', buf, offset)
+            keylen, = unpack_from(b'>B', buf, offset)
             offset += 1
             key = pstr_t(buf[offset:offset + keylen])
             offset += keylen
             val[key], offset = _read_item(buf, offset)
     # 'A': array
     elif ftype == 'A':
-        alen, = unpack_from('>I', buf, offset)
+        alen, = unpack_from(b'>I', buf, offset)
         offset += 4
         limit = offset + alen
         val = []
@@ -136,12 +136,12 @@ def _read_item(buf, offset=0, unpack_from=unpack_from, ftype_t=ftype_t):
             val.append(v)
     # 't' (bool)
     elif ftype == 't':
-        val, = unpack_from('>B', buf, offset)
+        val, = unpack_from(b'>B', buf, offset)
         val = bool(val)
         offset += 1
     # 'T': timestamp
     elif ftype == 'T':
-        val, = unpack_from('>Q', buf, offset)
+        val, = unpack_from(b'>Q', buf, offset)
         offset += 8
         val = datetime.utcfromtimestamp(val)
     # 'V': void
@@ -188,51 +188,51 @@ def loads(format, buf, offset=0,
             offset += 1
         elif p == 'o':
             bitcount = bits = 0
-            val, = unpack_from('>B', buf, offset)
+            val, = unpack_from(b'>B', buf, offset)
             offset += 1
         elif p == 'B':
             bitcount = bits = 0
-            val, = unpack_from('>H', buf, offset)
+            val, = unpack_from(b'>H', buf, offset)
             offset += 2
         elif p == 'l':
             bitcount = bits = 0
-            val, = unpack_from('>I', buf, offset)
+            val, = unpack_from(b'>I', buf, offset)
             offset += 4
         elif p == 'L':
             bitcount = bits = 0
-            val, = unpack_from('>Q', buf, offset)
+            val, = unpack_from(b'>Q', buf, offset)
             offset += 8
         elif p == 'f':
             bitcount = bits = 0
-            val, = unpack_from('>f', buf, offset)
+            val, = unpack_from(b'>f', buf, offset)
             offset += 4
         elif p == 's':
             bitcount = bits = 0
-            slen, = unpack_from('B', buf, offset)
+            slen, = unpack_from(b'B', buf, offset)
             offset += 1
             val = buf[offset:offset + slen].decode('utf-8')
             offset += slen
         elif p == 'S':
             bitcount = bits = 0
-            slen, = unpack_from('>I', buf, offset)
+            slen, = unpack_from(b'>I', buf, offset)
             offset += 4
             val = buf[offset:offset + slen].decode('utf-8')
             offset += slen
         elif p == 'F':
             bitcount = bits = 0
-            tlen, = unpack_from('>I', buf, offset)
+            tlen, = unpack_from(b'>I', buf, offset)
             offset += 4
             limit = offset + tlen
             val = {}
             while offset < limit:
-                keylen, = unpack_from('>B', buf, offset)
+                keylen, = unpack_from(b'>B', buf, offset)
                 offset += 1
                 key = pstr_t(buf[offset:offset + keylen])
                 offset += keylen
                 val[key], offset = _read_item(buf, offset)
         elif p == 'A':
             bitcount = bits = 0
-            alen, = unpack_from('>I', buf, offset)
+            alen, = unpack_from(b'>I', buf, offset)
             offset += 4
             limit = offset + alen
             val = []
@@ -241,7 +241,7 @@ def loads(format, buf, offset=0,
                 val.append(aval)
         elif p == 'T':
             bitcount = bits = 0
-            val, = unpack_from('>Q', buf, offset)
+            val, = unpack_from(b'>Q', buf, offset)
             offset += 8
             val = datetime.utcfromtimestamp(val)
         else:
@@ -252,7 +252,7 @@ def loads(format, buf, offset=0,
 
 def _flushbits(bits, write, pack=pack):
     if bits:
-        write(pack('B' * len(bits), *bits))
+        write(pack(b'B' * len(bits), *bits))
         bits[:] = []
     return 0
 
@@ -288,32 +288,32 @@ def dumps(format, values):
             bitcount += 1
         elif p == 'o':
             bitcount = _flushbits(bits, write)
-            write(pack('B', val))
+            write(pack(b'B', val))
         elif p == 'B':
             bitcount = _flushbits(bits, write)
-            write(pack('>H', int(val)))
+            write(pack(b'>H', int(val)))
         elif p == 'l':
             bitcount = _flushbits(bits, write)
-            write(pack('>I', val))
+            write(pack(b'>I', val))
         elif p == 'L':
             bitcount = _flushbits(bits, write)
-            write(pack('>Q', val))
+            write(pack(b'>Q', val))
         elif p == 'f':
             bitcount = _flushbits(bits, write)
-            write(pack('>f', val))
+            write(pack(b'>f', val))
         elif p == 's':
             val = val or ''
             bitcount = _flushbits(bits, write)
             if isinstance(val, string):
                 val = val.encode('utf-8')
-            write(pack('B', len(val)))
+            write(pack(b'B', len(val)))
             write(val)
         elif p == 'S':
             val = val or ''
             bitcount = _flushbits(bits, write)
             if isinstance(val, string):
                 val = val.encode('utf-8')
-            write(pack('>I', len(val)))
+            write(pack(b'>I', len(val)))
             write(val)
         elif p == 'F':
             bitcount = _flushbits(bits, write)
@@ -322,7 +322,7 @@ def dumps(format, values):
             bitcount = _flushbits(bits, write)
             _write_array(val or [], write, bits)
         elif p == 'T':
-            write(pack('>Q', long_t(mktime(val.timetuple()))))
+            write(pack(b'>Q', long_t(mktime(val.timetuple()))))
     _flushbits(bits, write)
 
     return out.getvalue()
@@ -334,7 +334,7 @@ def _write_table(d, write, bits, pack=pack):
     for k, v in items(d):
         if isinstance(k, string):
             k = k.encode('utf-8')
-        twrite(pack('B', len(k)))
+        twrite(pack(b'B', len(k)))
         twrite(k)
         try:
             _write_item(v, twrite, bits)
@@ -342,7 +342,7 @@ def _write_table(d, write, bits, pack=pack):
             raise FrameSyntaxError(
                 ILLEGAL_TABLE_TYPE_WITH_KEY.format(type(v), k, v))
     table_data = out.getvalue()
-    write(pack('>I', len(table_data)))
+    write(pack(b'>I', len(table_data)))
     write(table_data)
 
 
@@ -356,7 +356,7 @@ def _write_array(l, write, bits, pack=pack):
             raise FrameSyntaxError(
                 ILLEGAL_TABLE_TYPE_WITH_VALUE.format(type(v), v))
     array_data = out.getvalue()
-    write(pack('>I', len(array_data)))
+    write(pack(b'>I', len(array_data)))
     write(array_data)
 
 
@@ -368,14 +368,14 @@ def _write_item(v, write, bits, pack=pack,
     if isinstance(v, (string_t, bytes)):
         if isinstance(v, string):
             v = v.encode('utf-8')
-        write(pack('>cI', b'S', len(v)))
+        write(pack(b'>cI', b'S', len(v)))
         write(v)
     elif isinstance(v, bool):
-        write(pack('>cB', b't', int(v)))
+        write(pack(b'>cB', b't', int(v)))
     elif isinstance(v, float):
-        write(pack('>cd', b'd', v))
+        write(pack(b'>cd', b'd', v))
     elif isinstance(v, int_types):
-        write(pack('>ci', b'I', v))
+        write(pack(b'>ci', b'I', v))
     elif isinstance(v, Decimal):
         sign, digits, exponent = v.as_tuple()
         v = 0
@@ -383,9 +383,9 @@ def _write_item(v, write, bits, pack=pack,
             v = (v * 10) + d
         if sign:
             v = -v
-        write(pack('>cBi', b'D', -exponent, v))
+        write(pack(b'>cBi', b'D', -exponent, v))
     elif isinstance(v, datetime):
-        write(pack('>cQ', b'T', long_t(calendar.timegm(v.utctimetuple()))))
+        write(pack(b'>cQ', b'T', long_t(calendar.timegm(v.utctimetuple()))))
     elif isinstance(v, dict):
         write(b'F')
         _write_table(v, write, bits)
@@ -402,16 +402,16 @@ def decode_properties_basic(buf, offset=0,
                             unpack_from=unpack_from, pstr_t=pstr_t):
     properties = {}
 
-    flags, = unpack_from('>H', buf, offset)
+    flags, = unpack_from(b'>H', buf, offset)
     offset += 2
 
     if flags & 0x8000:
-        slen, = unpack_from('>B', buf, offset)
+        slen, = unpack_from(b'>B', buf, offset)
         offset += 1
         properties['content_type'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x4000:
-        slen, = unpack_from('>B', buf, offset)
+        slen, = unpack_from(b'>B', buf, offset)
         offset += 1
         properties['content_encoding'] = pstr_t(buf[offset:offset + slen])
         offset += slen
@@ -419,51 +419,51 @@ def decode_properties_basic(buf, offset=0,
         _f, offset = loads('F', buf, offset)
         properties['application_headers'], = _f
     if flags & 0x1000:
-        properties['delivery_mode'], = unpack_from('>B', buf, offset)
+        properties['delivery_mode'], = unpack_from(b'>B', buf, offset)
         offset += 1
     if flags & 0x0800:
-        properties['priority'], = unpack_from('>B', buf, offset)
+        properties['priority'], = unpack_from(b'>B', buf, offset)
         offset += 1
     if flags & 0x0400:
-        slen, = unpack_from('>B', buf, offset)
+        slen, = unpack_from(b'>B', buf, offset)
         offset += 1
         properties['correlation_id'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0200:
-        slen, = unpack_from('>B', buf, offset)
+        slen, = unpack_from(b'>B', buf, offset)
         offset += 1
         properties['reply_to'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0100:
-        slen, = unpack_from('>B', buf, offset)
+        slen, = unpack_from(b'>B', buf, offset)
         offset += 1
         properties['expiration'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0080:
-        slen, = unpack_from('>B', buf, offset)
+        slen, = unpack_from(b'>B', buf, offset)
         offset += 1
         properties['message_id'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0040:
-        properties['timestamp'], = unpack_from('>Q', buf, offset)
+        properties['timestamp'], = unpack_from(b'>Q', buf, offset)
         offset += 8
     if flags & 0x0020:
-        slen, = unpack_from('>B', buf, offset)
+        slen, = unpack_from(b'>B', buf, offset)
         offset += 1
         properties['type'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0010:
-        slen, = unpack_from('>B', buf, offset)
+        slen, = unpack_from(b'>B', buf, offset)
         offset += 1
         properties['user_id'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0008:
-        slen, = unpack_from('>B', buf, offset)
+        slen, = unpack_from(b'>B', buf, offset)
         offset += 1
         properties['app_id'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0004:
-        slen, = unpack_from('>B', buf, offset)
+        slen, = unpack_from(b'>B', buf, offset)
         offset += 1
         properties['cluster_id'] = pstr_t(buf[offset:offset + slen])
         offset += slen
@@ -547,13 +547,13 @@ class GenericContent(object):
         result = BytesIO()
         write = result.write
         for flag_bits in flags:
-            write(pack('>H', flag_bits))
+            write(pack(b'>H', flag_bits))
         write(dumps(b''.join(sformat), svalues))
 
         return result.getvalue()
 
     def inbound_header(self, buf, offset=0):
-        class_id, self.body_size = unpack_from('>HxxQ', buf, offset)
+        class_id, self.body_size = unpack_from(b'>HxxQ', buf, offset)
         offset += 12
         self._load_properties(class_id, buf, offset)
         if not self.body_size:

--- a/amqp/tests/test_method_framing.py
+++ b/amqp/tests/test_method_framing.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 from struct import pack
 

--- a/amqp/tests/test_method_framing.py
+++ b/amqp/tests/test_method_framing.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from struct import pack
 
@@ -19,21 +19,21 @@ class test_frame_handler(Case):
         self.g = frame_handler(self.conn, self.callback)
 
     def test_header(self):
-        buf = pack('>HH', 60, 51)
+        buf = pack(b'>HH', 60, 51)
         self.g((1, 1, buf))
         self.callback.assert_called_with(1, (60, 51), buf, None)
         self.assertTrue(self.conn.bytes_recv)
 
     def test_header_message_empty_body(self):
-        self.g((1, 1, pack('>HH', *spec.Basic.Deliver)))
+        self.g((1, 1, pack(b'>HH', *spec.Basic.Deliver)))
         self.callback.assert_not_called()
 
         with self.assertRaises(UnexpectedFrame):
-            self.g((1, 1, pack('>HH', *spec.Basic.Deliver)))
+            self.g((1, 1, pack(b'>HH', *spec.Basic.Deliver)))
 
         m = Message()
         m.properties = {}
-        buf = pack('>HxxQ', m.CLASS_ID, 0)
+        buf = pack(b'>HxxQ', m.CLASS_ID, 0)
         buf += m._serialize_properties()
         self.g((2, 1, buf))
 
@@ -44,12 +44,12 @@ class test_frame_handler(Case):
         )
 
     def test_header_message_content(self):
-        self.g((1, 1, pack('>HH', *spec.Basic.Deliver)))
+        self.g((1, 1, pack(b'>HH', *spec.Basic.Deliver)))
         self.callback.assert_not_called()
 
         m = Message()
         m.properties = {}
-        buf = pack('>HxxQ', m.CLASS_ID, 16)
+        buf = pack(b'>HxxQ', m.CLASS_ID, 16)
         buf += m._serialize_properties()
         self.g((2, 1, buf))
         self.callback.assert_not_called()

--- a/amqp/tests/test_serialization.py
+++ b/amqp/tests/test_serialization.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from datetime import datetime
 from decimal import Decimal
@@ -27,28 +27,28 @@ class test_serialization(Case):
         self.assertEqual(_read_item(b's8thequick')[0], 'thequick')
 
     def test_read_item_b(self):
-        self.assertEqual(_read_item(b'b' + pack('>B', True))[0], True)
+        self.assertEqual(_read_item(b'b' + pack(b'>B', True))[0], True)
 
     def test_read_item_B(self):
-        self.assertEqual(_read_item(b'B' + pack('>b', 123))[0], 123)
+        self.assertEqual(_read_item(b'B' + pack(b'>b', 123))[0], 123)
 
     def test_read_item_U(self):
-        self.assertEqual(_read_item(b'U' + pack('>h', -321))[0], -321)
+        self.assertEqual(_read_item(b'U' + pack(b'>h', -321))[0], -321)
 
     def test_read_item_u(self):
-        self.assertEqual(_read_item(b'u' + pack('>H', 321))[0], 321)
+        self.assertEqual(_read_item(b'u' + pack(b'>H', 321))[0], 321)
 
     def test_read_item_i(self):
-        self.assertEqual(_read_item(b'i' + pack('>I', 1234))[0], 1234)
+        self.assertEqual(_read_item(b'i' + pack(b'>I', 1234))[0], 1234)
 
     def test_read_item_L(self):
-        self.assertEqual(_read_item(b'L' + pack('>q', -32451))[0], -32451)
+        self.assertEqual(_read_item(b'L' + pack(b'>q', -32451))[0], -32451)
 
     def test_read_item_l(self):
-        self.assertEqual(_read_item(b'l' + pack('>Q', 32451))[0], 32451)
+        self.assertEqual(_read_item(b'l' + pack(b'>Q', 32451))[0], 32451)
 
     def test_read_item_f(self):
-        self.assertEqual(ceil(_read_item(b'f' + pack('>f', 33.3))[0]), 34.0)
+        self.assertEqual(ceil(_read_item(b'f' + pack(b'>f', 33.3))[0]), 34.0)
 
     def test_read_item_V(self):
         self.assertIsNone(_read_item(b'V')[0])
@@ -170,7 +170,7 @@ class test_GenericContent(Case):
             'content_encoding': 'utf-8',
         }
         body = 'the quick brown fox'
-        buf = b'\0' * 30 + pack('>HxxQ', m.CLASS_ID, len(body))
+        buf = b'\0' * 30 + pack(b'>HxxQ', m.CLASS_ID, len(body))
         buf += m._serialize_properties()
         self.assertEqual(m.inbound_header(buf, offset=30), 42)
         self.assertEqual(m.body_size, len(body))
@@ -180,7 +180,7 @@ class test_GenericContent(Case):
     def test_inbound_header__empty_body(self):
         m = Message()
         m.properties = {}
-        buf = pack('>HxxQ', m.CLASS_ID, 0)
+        buf = pack(b'>HxxQ', m.CLASS_ID, 0)
         buf += m._serialize_properties()
         self.assertEqual(m.inbound_header(buf, offset=0), 12)
         self.assertTrue(m.ready)

--- a/amqp/tests/test_serialization.py
+++ b/amqp/tests/test_serialization.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 from datetime import datetime
 from decimal import Decimal

--- a/amqp/tests/test_transport.py
+++ b/amqp/tests/test_transport.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import errno
 import socket
@@ -258,11 +258,11 @@ class test_AbstractTransport(Case):
             self.t._read.return_value = b'thequickbrownfox'
             self.t._read.side_effect = on_read2
             return ret
-        self.t._read.return_value = pack('>BHI', 1, 1, 16)
+        self.t._read.return_value = pack(b'>BHI', 1, 1, 16)
         self.t._read.side_effect = on_read1
 
         self.t.read_frame()
-        self.t._read.return_value = pack('>BHI', 1, 1, 16)
+        self.t._read.return_value = pack(b'>BHI', 1, 1, 16)
         self.t._read.side_effect = on_read1
         checksum[0] = b'\x13'
         with self.assertRaises(UnexpectedFrame):

--- a/amqp/tests/test_transport.py
+++ b/amqp/tests/test_transport.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 import errno
 import socket


### PR DESCRIPTION
The existing version breaks on Python 2.7 because `struct()` needs bytes as the 1st parameter, not unicode.