### PR TITLE
patch to fix struct pack/unpack unicode error when python version < 2.7.7

### DIFF
--- a/amqp/exceptions.py
+++ b/amqp/exceptions.py
@@ -16,9 +16,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 from __future__ import absolute_import, unicode_literals
 
-from struct import pack, unpack
-
 from .five import python_2_unicode_compatible
+from .utils import pack, unpack
 
 __all__ = [
     'AMQPError',
@@ -260,5 +259,4 @@ METHOD_NAME_MAP = {
 
 
 for _method_id, _method_name in list(METHOD_NAME_MAP.items()):
-    METHOD_NAME_MAP[unpack(u'>I', pack(u'>HH', *_method_id))[0]] = \
-        _method_name
+    METHOD_NAME_MAP[unpack('>I', pack('>HH', *_method_id))[0]] = _method_name

--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -17,13 +17,12 @@
 from __future__ import absolute_import, unicode_literals
 
 from collections import defaultdict
-from struct import pack, unpack_from, pack_into
 
 from . import spec
 from .basic_message import Message
 from .exceptions import UnexpectedFrame
 from .five import range
-from .utils import coro, str_to_bytes
+from .utils import coro, str_to_bytes, pack, pack_into, unpack_from
 
 __all__ = ['frame_handler', 'frame_writer']
 

--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -27,13 +27,12 @@ import sys
 from datetime import datetime
 from decimal import Decimal
 from io import BytesIO
-from struct import pack, unpack_from
 from time import mktime
 
 from .spec import Basic
 from .exceptions import FrameSyntaxError
 from .five import int_types, long_t, string, string_t, items
-from .utils import bytes_to_str as pstr_t, str_to_bytes
+from .utils import bytes_to_str as pstr_t, str_to_bytes, pack, unpack_from
 
 ftype_t = chr if sys.version_info[0] == 3 else None
 

--- a/amqp/tests/test_method_framing.py
+++ b/amqp/tests/test_method_framing.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import, unicode_literals
 
-from struct import pack
-
 from amqp import spec
 from amqp.basic_message import Message
 from amqp.exceptions import UnexpectedFrame
 from amqp.method_framing import frame_handler, frame_writer
+from amqp.utils import pack
 
 from .case import Case, Mock
 

--- a/amqp/tests/test_serialization.py
+++ b/amqp/tests/test_serialization.py
@@ -3,11 +3,11 @@ from __future__ import absolute_import, unicode_literals
 from datetime import datetime
 from decimal import Decimal
 from math import ceil
-from struct import pack
 
 from amqp.basic_message import Message
 from amqp.exceptions import FrameSyntaxError
 from amqp.serialization import GenericContent, _read_item, dumps, loads
+from amqp.utils import pack
 
 from .case import Case
 

--- a/amqp/tests/test_transport.py
+++ b/amqp/tests/test_transport.py
@@ -3,10 +3,9 @@ from __future__ import absolute_import, unicode_literals
 import errno
 import socket
 
-from struct import pack
-
 from amqp import transport
 from amqp.exceptions import UnexpectedFrame
+from amqp.utils import pack
 
 from .case import Case, Mock, patch
 

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -17,16 +17,14 @@ from __future__ import absolute_import, unicode_literals
 
 import errno
 import re
-import struct
 import socket
 import ssl
 
 from contextlib import contextmanager
-from struct import unpack
 
 from .exceptions import UnexpectedFrame
 from .five import items
-from .utils import get_errno, set_cloexec
+from .utils import get_errno, set_cloexec, pack, unpack
 
 # Jython does not have this attribute
 try:
@@ -159,7 +157,7 @@ class _AbstractTransport(object):
                 if interval is not None:
                     self.sock.setsockopt(
                         socket.SOL_SOCKET, timeout,
-                        struct.pack('ll', interval, 0),
+                        pack('ll', interval, 0),
                     )
             self._setup_transport()
 

--- a/amqp/utils.py
+++ b/amqp/utils.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 import sys
+from struct import pack, unpack, pack_into, unpack_from
 
 # enables celery 3.1.23 to start again
 from vine import promise                # noqa
@@ -82,6 +83,18 @@ else:
 
     def bytes_to_str(s):                # noqa
         return s
+
+    if sys.version_info < (2, 7, 7):
+        import functools
+
+        def decorator(func):
+            @functools.wraps(func)
+            def wrapper(pattern, *args, **kwds):
+                return func(str(pattern), *args, **kwds)
+            return wrapper
+
+        _funcs = (pack, unpack, pack_into, unpack_from)
+        pack, unpack, pack_into, unpack_from = map(decorator, _funcs)
 
 
 class NullHandler(logging.Handler):


### PR DESCRIPTION
patch to fix "TypeError: Struct() argument 1 must be string, not unicode" when python version < 2.7.7