### PR TITLE
Solve unicode bugs on struct

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -352,7 +352,7 @@ class Connection(AbstractChannel):
 
         # Negotiate protocol extensions (capabilities)
         scap = server_properties.get('capabilities') or {}
-        print('SCAP: %r' %( scap,))
+        print('SCAP: %r' % (scap,))
         cap = client_properties.setdefault('capabilities', {})
         cap.update({
             wanted_cap: enable_cap

--- a/amqp/exceptions.py
+++ b/amqp/exceptions.py
@@ -260,5 +260,5 @@ METHOD_NAME_MAP = {
 
 
 for _method_id, _method_name in list(METHOD_NAME_MAP.items()):
-    METHOD_NAME_MAP[unpack(u'>I', pack(u'>HH', *_method_id))[0]] = \
+    METHOD_NAME_MAP[unpack(b'>I', pack(b'>HH', *_method_id))[0]] = \
         _method_name

--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -115,7 +115,7 @@ def frame_writer(connection, transport,
                                str_to_bytes(args)])
                      if type_ == 1 else b'')  # encode method frame
             framelen = len(frame)
-            write(pack((b'>BHI%dsB' % framelen).encode(),
+            write(pack((str('>BHI%dsB') % framelen).encode(),
                        type_, channel, framelen, frame, 0xce))
             if body:
                 properties = content._serialize_properties()
@@ -124,13 +124,13 @@ def frame_writer(connection, transport,
                     properties,
                 ])
                 framelen = len(frame)
-                write(pack((b'>BHI%dsB' % framelen).encode(),
+                write(pack((str('>BHI%dsB') % framelen).encode(),
                            2, channel, framelen, frame, 0xce))
 
                 for i in range(0, bodylen, chunk_size):
                     frame = body[i:i + chunk_size]
                     framelen = len(frame)
-                    write(pack((b'>BHI%dsB' % framelen).encode(),
+                    write(pack((str('>BHI%dsB') % framelen).encode(),
                                3, channel, framelen,
                                str_to_bytes(frame), 0xce))
 
@@ -140,7 +140,7 @@ def frame_writer(connection, transport,
                                str_to_bytes(args)])
                      if type_ == 1 else b'')
             framelen = len(frame)
-            pack_into((b'>BHI%dsB' % framelen).encode(), buf, offset,
+            pack_into((str('>BHI%dsB') % framelen).encode(), buf, offset,
                       type_, channel, framelen, frame, 0xce)
             offset += 8 + framelen
             if body:
@@ -151,12 +151,12 @@ def frame_writer(connection, transport,
                 ])
                 framelen = len(frame)
 
-                pack_into((b'>BHI%dsB' % framelen).encode(), buf, offset,
+                pack_into((str('>BHI%dsB') % framelen).encode(), buf, offset,
                           2, channel, framelen, frame, 0xce)
                 offset += 8 + framelen
 
                 framelen = len(body)
-                pack_into((b'>BHI%dsB' % framelen).encode(), buf, offset,
+                pack_into((str('>BHI%dsB') % framelen).encode(), buf, offset,
                           3, channel, framelen, str_to_bytes(body), 0xce)
                 offset += 8 + framelen
 

--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -51,7 +51,7 @@ def frame_handler(connection, callback,
                     frame_type, expected_types[channel]),
             )
         elif frame_type == 1:
-            method_sig = unpack_from(u'>HH', buf, 0)
+            method_sig = unpack_from(b'>HH', buf, 0)
 
             if method_sig in content_methods:
                 # Save what we've got so far and wait for the content-header
@@ -115,7 +115,7 @@ def frame_writer(connection, transport,
                                str_to_bytes(args)])
                      if type_ == 1 else b'')  # encode method frame
             framelen = len(frame)
-            write(pack((u'>BHI%dsB' % framelen).encode(),
+            write(pack((b'>BHI%dsB' % framelen).encode(),
                        type_, channel, framelen, frame, 0xce))
             if body:
                 properties = content._serialize_properties()
@@ -124,13 +124,13 @@ def frame_writer(connection, transport,
                     properties,
                 ])
                 framelen = len(frame)
-                write(pack((u'>BHI%dsB' % framelen).encode(),
+                write(pack((b'>BHI%dsB' % framelen).encode(),
                            2, channel, framelen, frame, 0xce))
 
                 for i in range(0, bodylen, chunk_size):
                     frame = body[i:i + chunk_size]
                     framelen = len(frame)
-                    write(pack((u'>BHI%dsB' % framelen).encode(),
+                    write(pack((b'>BHI%dsB' % framelen).encode(),
                                3, channel, framelen,
                                str_to_bytes(frame), 0xce))
 
@@ -140,7 +140,7 @@ def frame_writer(connection, transport,
                                str_to_bytes(args)])
                      if type_ == 1 else b'')
             framelen = len(frame)
-            pack_into((u'>BHI%dsB' % framelen).encode(), buf, offset,
+            pack_into((b'>BHI%dsB' % framelen).encode(), buf, offset,
                       type_, channel, framelen, frame, 0xce)
             offset += 8 + framelen
             if body:
@@ -151,12 +151,12 @@ def frame_writer(connection, transport,
                 ])
                 framelen = len(frame)
 
-                pack_into((u'>BHI%dsB' % framelen).encode(), buf, offset,
+                pack_into((b'>BHI%dsB' % framelen).encode(), buf, offset,
                           2, channel, framelen, frame, 0xce)
                 offset += 8 + framelen
 
                 framelen = len(body)
-                pack_into((u'>BHI%dsB' % framelen).encode(), buf, offset,
+                pack_into((b'>BHI%dsB' % framelen).encode(), buf, offset,
                           3, channel, framelen, str_to_bytes(body), 0xce)
                 offset += 8 + framelen
 

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -159,7 +159,7 @@ class _AbstractTransport(object):
                 if interval is not None:
                     self.sock.setsockopt(
                         socket.SOL_SOCKET, timeout,
-                        struct.pack('ll', interval, 0),
+                        struct.pack(b'll', interval, 0),
                     )
             self._setup_transport()
 
@@ -220,7 +220,7 @@ class _AbstractTransport(object):
         try:
             frame_header = read(7, True)
             read_frame_buffer += frame_header
-            frame_type, channel, size = unpack(u'>BHI', frame_header)
+            frame_type, channel, size = unpack(b'>BHI', frame_header)
             # >I is an unsigned int, but the argument to sock.recv is signed,
             # so we know the size can be at most 2 * SIGNED_INT_MAX
             if size > SIGNED_INT_MAX:


### PR DESCRIPTION
Python <= 2.7.7 requires native strings for the first argument of `struct.pack`, `struct.unpack`, etc.
Newer versions of Python (including recent 3.x) accept bytestrings (which are the same as `str` in 2.x anyway). The safest way to keep compatibility while still using `from __future__ import unicode_literals` seems to be to standardize on bytestring notation throughout.