### PR TITLE
Refactored to make authn modular; added GSSAPI

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -21,8 +21,6 @@ import socket
 import uuid
 import warnings
 
-from io import BytesIO
-
 from vine import ensure_promise
 
 from . import __version__
@@ -37,7 +35,6 @@ from .exceptions import (
 from .five import array, items, monotonic, range, values
 from .method_framing import frame_handler, frame_writer
 from .sasl import AMQPLAIN, PLAIN, SASL
-from .serialization import _write_table
 from .transport import Transport
 
 try:
@@ -375,7 +372,7 @@ class Connection(AbstractChannel):
         else:
             raise Exception(
                 "Couldn't find appropriate auth mechanism "
-                "(can offer {0}; available {1})".format(
+                "(can offer: {0}; available: {1})".format(
                     b", ".join(m.mechanism for m in self.authentication).decode(),
                     b", ".join(self.mechanisms).decode()))
 

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -342,7 +342,7 @@ class Connection(AbstractChannel):
         self.version_major = version_major
         self.version_minor = version_minor
         self.server_properties = server_properties
-        self.mechanisms = mechanisms.split(' ')
+        self.mechanisms = mechanisms.split(b' ')
         self.locales = locales.split(' ')
         AMQP_LOGGER.debug(
             START_DEBUG_FMT,
@@ -367,7 +367,11 @@ class Connection(AbstractChannel):
             if authentication.mechanism in self.mechanisms:
                 break
         else:
-            raise Exception("Couldn't find appropriate auth mechanism")
+            raise Exception(
+                "Couldn't find appropriate auth mechanism "
+                "(can offer {0}; available {1})".format(
+                    b", ".join(m.mechanism for m in self.authentication).decode(),
+                    b", ".join(self.mechanisms).decode()))
 
         self.send_method(
             spec.Connection.StartOk, argsig,

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -24,6 +24,7 @@ import warnings
 from vine import ensure_promise
 
 from . import __version__
+from . import sasl
 from . import spec
 from .abstract_channel import AbstractChannel
 from .channel import Channel
@@ -34,7 +35,6 @@ from .exceptions import (
 )
 from .five import array, items, monotonic, range, values
 from .method_framing import frame_handler, frame_writer
-from .sasl import AMQPLAIN, PLAIN, SASL
 from .transport import Transport
 
 try:
@@ -204,12 +204,14 @@ class Connection(AbstractChannel):
                 "heeded; use authentication parameter instead",
                 DeprecationWarning)
         if authentication:
-            if isinstance(authentication, SASL):
+            if isinstance(authentication, sasl.SASL):
                 authentication = (authentication,)
             self.authentication = authentication
+        elif login_method is not None and login_response is not None:
+            self.authentication = (sasl.RAW(login_method, login_response))
         elif userid is not None and password is not None:
-            self.authentication = (AMQPLAIN(userid, password),
-                                   PLAIN(userid, password))
+            self.authentication = (sasl.AMQPLAIN(userid, password),
+                                   sasl.PLAIN(userid, password))
         else:
             raise ValueError("Must supply authentication or userid/password")
 

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -211,7 +211,8 @@ class Connection(AbstractChannel):
                 authentication = (authentication,)
             self.authentication = authentication
         elif userid is not None and password is not None:
-            self.authentication = (AMQPLAIN(userid, password),)
+            self.authentication = (AMQPLAIN(userid, password),
+                                   PLAIN(userid, password))
         else:
             raise ValueError("Must supply authentication or userid/password")
 

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -368,7 +368,7 @@ class Connection(AbstractChannel):
             if authentication.mechanism in self.mechanisms:
                 break
         else:
-            raise Exception(
+            raise ConnectionError(
                 "Couldn't find appropriate auth mechanism "
                 "(can offer: {0}; available: {1})".format(
                     b", ".join(m.mechanism

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -206,9 +206,9 @@ class Connection(AbstractChannel):
         elif login_method is not None and login_response is not None:
             self.authentication = (sasl.RAW(login_method, login_response),)
         elif userid is not None and password is not None:
-            self.authentication = (sasl.AMQPLAIN(userid, password),
-                                   sasl.PLAIN(userid, password),
-                                   sasl.GSSAPI(userid, fail_soft=True))
+            self.authentication = (sasl.GSSAPI(userid, fail_soft=True),
+                                   sasl.AMQPLAIN(userid, password),
+                                   sasl.PLAIN(userid, password))
         else:
             raise ValueError("Must supply authentication or userid/password")
 

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -199,16 +199,12 @@ class Connection(AbstractChannel):
         self._connection_id = uuid.uuid4().hex
         channel_max = channel_max or 65535
         frame_max = frame_max or 131072
-        if login_method is not None or login_response is not None:
-            warnings.warn("login_method and login_response are no longer "
-                "heeded; use authentication parameter instead",
-                DeprecationWarning)
         if authentication:
             if isinstance(authentication, sasl.SASL):
                 authentication = (authentication,)
             self.authentication = authentication
         elif login_method is not None and login_response is not None:
-            self.authentication = (sasl.RAW(login_method, login_response))
+            self.authentication = (sasl.RAW(login_method, login_response),)
         elif userid is not None and password is not None:
             self.authentication = (sasl.AMQPLAIN(userid, password),
                                    sasl.PLAIN(userid, password))
@@ -375,7 +371,8 @@ class Connection(AbstractChannel):
             raise Exception(
                 "Couldn't find appropriate auth mechanism "
                 "(can offer: {0}; available: {1})".format(
-                    b", ".join(m.mechanism for m in self.authentication).decode(),
+                    b", ".join(m.mechanism
+                               for m in self.authentication).decode(),
                     b", ".join(self.mechanisms).decode()))
 
         self.send_method(

--- a/amqp/sasl.py
+++ b/amqp/sasl.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from io import BytesIO
 import abc

--- a/amqp/sasl.py
+++ b/amqp/sasl.py
@@ -102,6 +102,8 @@ class RAW(SASL):
     mechanism = None
 
     def __init__(self, mechanism, response):
+        assert isinstance(mechanism, bytes)
+        assert isinstance(response, bytes)
         self.mechanism, self.response = mechanism, response
         warnings.warn("Passing login_method and login_response to Connection "
                       "is deprecated. Please implement a SASL subclass "

--- a/amqp/sasl.py
+++ b/amqp/sasl.py
@@ -1,0 +1,73 @@
+from __future__ import unicode_literals
+
+from io import BytesIO
+import abc
+import socket
+
+from amqp.serialization import _write_table
+
+
+class SASL(object):
+    pass
+
+
+class PLAIN(SASL):
+    mechanism = b'PLAIN'
+    # As per https://tools.ietf.org/html/rfc4616
+
+    def __init__(self, username, password):
+        self.username, self.password = username, password
+
+    def start(self, connection):
+        login_response = BytesIO()
+        login_response.write(b'\0')
+        login_response.write(self.username.encode('utf-8'))
+        login_response.write(b'\0')
+        login_response.write(self.password.encode('utf-8'))
+        return login_response.getvalue()
+
+
+class AMQPLAIN(SASL):
+    mechanism = b'AMQPLAIN'
+
+    def __init__(self, username, password):
+        self.username, self.password = username, password
+
+    def start(self, connection):
+        login_response = BytesIO()
+        _write_table({b'LOGIN': self.username, b'PASSWORD': self.password},
+                     login_response.write, [])
+        # Skip the length at the beginning
+        return login_response.getvalue()[4:]
+
+try:
+    import gssapi
+except ImportError:
+    pass
+else:
+    class GSSAPI(SASL):
+        mechanism = b'GSSAPI'
+
+        def __init__(self, service=b'amqp', rdns=False):
+            self.service = service
+            self.rdns = rdns
+
+        def get_hostname(self, connection):
+            if self.rdns:
+                peer = connection.transport.sock.getpeername()
+                if isinstance(peer, tuple) and len(peer) == 2:
+                    hostname, _, _ = socket.gethostbyaddr(peer[0])
+                    return hostname
+                else:
+                    raise AssertionError
+            else:
+                return connection.transport.host
+
+        def start(self, connection):
+            name = gssapi.Name(b'{}@{}'.format(self.service,
+                                              self.get_hostname(connection)),
+                               gssapi.NameType.hostbased_service)
+            self.context = gssapi.SecurityContext(name=name)
+            data = self.context.step(None)
+            return data
+

--- a/amqp/sasl.py
+++ b/amqp/sasl.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, unicode_literals
 from io import BytesIO
 import socket
 
+import warnings
+
 from amqp.serialization import _write_table
 
 
@@ -89,8 +91,21 @@ else:
 
         def start(self, connection):
             name = gssapi.Name(b'{}@{}'.format(self.service,
-                                              self.get_hostname(connection)),
+                                               self.get_hostname(connection)),
                                gssapi.NameType.hostbased_service)
             self.context = gssapi.SecurityContext(name=name)
             data = self.context.step(None)
             return data
+
+
+class RAW(SASL):
+    mechanism = None
+
+    def __init__(self, mechanism, response):
+        self.mechanism, self.response = mechanism, response
+        warnings.warn("Passing login_method and login_response to Connection "
+                      "is deprecated. Please implement a SASL subclass "
+                      "instead.", DeprecationWarning)
+
+    def start(self, connection):
+        return self.response

--- a/amqp/sasl.py
+++ b/amqp/sasl.py
@@ -1,3 +1,4 @@
+"""SASL mechanisms for AMQP authentication."""
 from __future__ import absolute_import, unicode_literals
 
 from io import BytesIO
@@ -9,28 +10,27 @@ from amqp.serialization import _write_table
 
 
 class SASL(object):
-    """
-    The base class for all amqp SASL authentication mechanisms
+    """The base class for all amqp SASL authentication mechanisms.
 
     You should sub-class this if you're implementing your own authentication.
     """
 
     @property
     def mechanism(self):
-        """Returns a bytes containing the SASL mechanism name"""
+        """Return a bytes containing the SASL mechanism name."""
         raise NotImplementedError
 
     def start(self, connection):
-        """Returns the first response to a SASL challenge as a bytes object"""
+        """Return the first response to a SASL challenge as a bytes object."""
         raise NotImplementedError
 
 
 class PLAIN(SASL):
-    """
-    PLAIN SASL authentication mechanism.
+    """PLAIN SASL authentication mechanism.
 
     See https://tools.ietf.org/html/rfc4616 for details
     """
+
     mechanism = b'PLAIN'
 
     def __init__(self, username, password):
@@ -46,6 +46,11 @@ class PLAIN(SASL):
 
 
 class AMQPLAIN(SASL):
+    """AMQPLAIN SASL authentication mechanism.
+
+    This is a non-standard mechanism used by AMQP servers.
+    """
+
     mechanism = b'AMQPLAIN'
 
     def __init__(self, username, password):
@@ -64,7 +69,8 @@ def _get_gssapi_mechanism():
         import gssapi
     except ImportError:
         class FakeGSSAPI(SASL):
-            """A no op SASL mechanism for when gssapi isn't available"""
+            """A no-op SASL mechanism for when gssapi isn't available."""
+
             mechanism = None
 
             def __init__(self, client_name=None, service=b'amqp',
@@ -81,11 +87,11 @@ def _get_gssapi_mechanism():
         import gssapi.raw.misc
 
         class GSSAPI(SASL):
-            """
-            GSSAPI SASL authentication mechanism
+            """GSSAPI SASL authentication mechanism.
 
             See https://tools.ietf.org/html/rfc4752 for details
             """
+
             mechanism = b'GSSAPI'
 
             def __init__(self, client_name=None, service=b'amqp',
@@ -133,6 +139,12 @@ GSSAPI = _get_gssapi_mechanism()
 
 
 class RAW(SASL):
+    """A generic custom SASL mechanism.
+
+    This mechanism takes a mechanism name and response to send to the server,
+    so can be used for simple custom authentication schemes.
+    """
+
     mechanism = None
 
     def __init__(self, mechanism, response):

--- a/amqp/sasl.py
+++ b/amqp/sasl.py
@@ -80,7 +80,7 @@ def _get_gssapi_mechanism():
                         "You need to install the `gssapi` module for GSSAPI "
                         "SASL support")
 
-            def start(self):
+            def start(self):  # pragma: no cover
                 return NotImplemented
         return FakeGSSAPI
     else:
@@ -104,12 +104,11 @@ def _get_gssapi_mechanism():
                 self.rdns = rdns
 
             def get_hostname(self, connection):
-                if self.rdns:
-                    peer = connection.transport.sock.getpeername()
-                    if isinstance(peer, tuple) and len(peer) == 2:
-                        hostname, _, _ = socket.gethostbyaddr(peer[0])
-                    else:
-                        raise AssertionError
+                sock = connection.transport.sock
+                if self.rdns and sock.family in (socket.AF_INET,
+                                                 socket.AF_INET6):
+                    peer = sock.getpeername()
+                    hostname, _, _ = socket.gethostbyaddr(peer[0])
                 else:
                     hostname = connection.transport.host
                 if not isinstance(hostname, bytes):

--- a/amqp/sasl.py
+++ b/amqp/sasl.py
@@ -90,6 +90,8 @@ def _get_gssapi_mechanism():
 
             def __init__(self, client_name=None, service=b'amqp',
                          rdns=False, fail_soft=False):
+                if client_name and not isinstance(client_name, bytes):
+                    client_name = client_name.encode('ascii')
                 self.client_name = client_name
                 self.fail_soft = fail_soft
                 self.service = service

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -270,7 +270,7 @@ class SSLTransport(_AbstractTransport):
 
     def _setup_transport(self):
         """Wrap the socket in an SSL object."""
-        self.sock = self._wrap_socket(self.sock, **self.sslopts or {})
+        self.sock = self._wrap_socket(self.sock, **self.sslopts)
         self.sock.do_handshake()
         self._quick_recv = self.sock.read
 

--- a/docs/reference/amqp.sasl.rst
+++ b/docs/reference/amqp.sasl.rst
@@ -1,0 +1,11 @@
+=====================================================
+ amqp.spec
+=====================================================
+
+.. contents::
+    :local:
+.. currentmodule:: amqp.sasl
+
+.. automodule:: amqp.sasl
+    :members:
+    :undoc-members:

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -18,6 +18,7 @@
     amqp.transport
     amqp.method_framing
     amqp.protocol
+    amqp.sasl
     amqp.serialization
     amqp.spec
     amqp.utils

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -99,6 +99,17 @@ class test_Connection:
             ),
         )
 
+    def test_missing_credentials(self):
+        with pytest.raises(ValueError):
+            self.conn = Connection(userid=None, password=None)
+        with pytest.raises(ValueError):
+            self.conn = Connection(password=None)
+
+    def test_mechanism_mismatch(self):
+        with pytest.raises(ConnectionError):
+            self.conn._on_start(3, 4, {'foo': 'bar'}, b'x y z',
+                                'en_US en_GB')
+
     def test_login_method_response(self):
         # An old way of doing things.:
         login_method, login_response = b'foo', b'bar'

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -119,7 +119,6 @@ class test_Connection:
             ),
         )
 
-
     def test_on_start__consumer_cancel_notify(self):
         self.conn._on_start(
             3, 4, {'capabilities': {'consumer_cancel_notify': 1}},

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -37,17 +37,22 @@ class test_Connection:
         self.conn = Connection(authentication=authentication)
         assert self.conn.authentication == (authentication,)
 
+    def test_sasl_authentication_iterable(self):
+        authentication = SASL()
+        self.conn = Connection(authentication=(authentication,))
+        assert self.conn.authentication == (authentication,)
+
     def test_amqplain(self):
         self.conn = Connection(userid='foo', password='bar')
-        assert isinstance(self.conn.authentication[0], AMQPLAIN)
-        assert self.conn.authentication[0].username == 'foo'
-        assert self.conn.authentication[0].password == 'bar'
+        assert isinstance(self.conn.authentication[1], AMQPLAIN)
+        assert self.conn.authentication[1].username == 'foo'
+        assert self.conn.authentication[1].password == 'bar'
 
     def test_plain(self):
         self.conn = Connection(userid='foo', password='bar')
-        assert isinstance(self.conn.authentication[1], PLAIN)
-        assert self.conn.authentication[1].username == 'foo'
-        assert self.conn.authentication[1].password == 'bar'
+        assert isinstance(self.conn.authentication[2], PLAIN)
+        assert self.conn.authentication[2].username == 'foo'
+        assert self.conn.authentication[2].password == 'bar'
 
     def test_enter_exit(self):
         self.conn.connect = Mock(name='connect')

--- a/t/unit/test_sasl.py
+++ b/t/unit/test_sasl.py
@@ -1,0 +1,111 @@
+from __future__ import absolute_import, unicode_literals
+
+from io import BytesIO
+
+from case import Mock, patch
+import pytest
+import sys
+
+from amqp import sasl
+from amqp.serialization import _write_table
+
+
+class tet_SASL:
+    def test_sasl_notimplemented(self):
+        mech = sasl.SASL()
+        with pytest.raises(NotImplementedError):
+            mech.mechanism
+        with pytest.raises(NotImplementedError):
+            mech.start(None)
+
+    def test_plain(self):
+        username, password = 'foo', 'bar'
+        mech = sasl.PLAIN(username, password)
+        response = mech.start(None)
+        assert isinstance(response, bytes)
+        assert response.split(b'\0') == \
+            [b'', username.encode('utf-8'), password.encode('utf-8')]
+
+    def test_amqplain(self):
+        username, password = 'foo', 'bar'
+        mech = sasl.AMQPLAIN(username, password)
+        response = mech.start(None)
+        assert isinstance(response, bytes)
+        login_response = BytesIO()
+        _write_table({b'LOGIN': username, b'PASSWORD': password},
+                     login_response.write, [])
+        expected_response = login_response.getvalue()[4:]
+        assert response == expected_response
+
+    def test_gssapi_missing(self):
+        gssapi = sys.modules.pop('gssapi', None)
+        GSSAPI = sasl._get_gssapi_mechanism()
+        with pytest.raises(NotImplementedError):
+            GSSAPI()
+        if gssapi is not None:
+            sys.modules['gssapi'] = gssapi
+
+    @patch('socket.gethostbyaddr')
+    def test_gssapi_rdns(self, gethostbyaddr):
+        orig_gssapi = sys.modules.pop('gssapi', None)
+        gssapi = sys.modules['gssapi'] = Mock()
+        connection = Mock()
+        connection.transport.sock.getpeername.return_value = ('192.0.2.0',
+                                                              5672)
+        gethostbyaddr.return_value = ('broker.example.org', (), ())
+        GSSAPI = sasl._get_gssapi_mechanism()
+
+        mech = GSSAPI(rdns=True)
+        mech.start(connection)
+
+        connection.transport.sock.getpeername.assert_called()
+        gethostbyaddr.assert_called_with('192.0.2.0')
+        gssapi.Name.assert_called_with(b'amqp@broker.example.org',
+                                       gssapi.NameType.hostbased_service)
+
+        if orig_gssapi is None:
+            del sys.modules['gssapi']
+        else:
+            sys.modules['gssapi'] = orig_gssapi
+
+    def test_gssapi_no_rdns(self):
+        orig_gssapi = sys.modules.pop('gssapi', None)
+        gssapi = sys.modules['gssapi'] = Mock()
+        connection = Mock()
+        connection.transport.host = 'broker.example.org'
+        GSSAPI = sasl._get_gssapi_mechanism()
+
+        mech = GSSAPI()
+        mech.start(connection)
+
+        gssapi.Name.assert_called_with(b'amqp@broker.example.org',
+                                       gssapi.NameType.hostbased_service)
+
+        if orig_gssapi is None:
+            del sys.modules['gssapi']
+        else:
+            sys.modules['gssapi'] = orig_gssapi
+
+    def test_gssapi_step(self):
+        orig_gssapi = sys.modules.pop('gssapi', None)
+        gssapi = sys.modules['gssapi'] = Mock()
+        context = Mock()
+        context.step.return_value = b'secrets'
+        name = Mock()
+        gssapi.SecurityContext.return_value = context
+        gssapi.Name = name
+        connection = Mock()
+        connection.transport.host = 'broker.example.org'
+        GSSAPI = sasl._get_gssapi_mechanism()
+
+        mech = GSSAPI()
+        response = mech.start(connection)
+
+        gssapi.SecurityContext.assert_called_with(name=name)
+        context.step.assert_called_with(None)
+        assert response == b'secrets'
+
+        if orig_gssapi is None:
+            del sys.modules['gssapi']
+        else:
+            sys.modules['gssapi'] = orig_gssapi

--- a/t/unit/test_sasl.py
+++ b/t/unit/test_sasl.py
@@ -10,7 +10,7 @@ from amqp import sasl
 from amqp.serialization import _write_table
 
 
-class tet_SASL:
+class test_SASL:
     def test_sasl_notimplemented(self):
         mech = sasl.SASL()
         with pytest.raises(NotImplementedError):
@@ -93,7 +93,7 @@ class tet_SASL:
         context.step.return_value = b'secrets'
         name = Mock()
         gssapi.SecurityContext.return_value = context
-        gssapi.Name = name
+        gssapi.Name.return_value = name
         connection = Mock()
         connection.transport.host = 'broker.example.org'
         GSSAPI = sasl._get_gssapi_mechanism()

--- a/t/unit/test_sasl.py
+++ b/t/unit/test_sasl.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import contextlib
+import socket
 from io import BytesIO
 
 from case import Mock, patch, call
@@ -81,6 +82,7 @@ class test_SASL:
             connection = Mock()
             connection.transport.sock.getpeername.return_value = ('192.0.2.0',
                                                                   5672)
+            connection.transport.sock.family = socket.AF_INET
             gethostbyaddr.return_value = ('broker.example.org', (), ())
             GSSAPI = sasl._get_gssapi_mechanism()
 

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -324,7 +324,7 @@ class test_SSLTransport:
         self.t.sock.do_handshake.assert_called_with()
         assert self.t._quick_recv is self.t.sock.read
 
-    @patch('ssl.wrap_socket', create=True)
+    @patch('ssl.wrap_socket')
     def test_wrap_socket(self, wrap_socket):
         sock = Mock()
         self.t._wrap_context = Mock()


### PR DESCRIPTION
This is an early pull request to achieve two things:
- make the authentication aspects more extensible
- implement GSSAPI authentication as an option

I'm not expecting it to be merged immediately, but it'd be good to have some initial feedback.

WRT the GSSAPI stuff, I've written a [rabbitmq module](https://github.com/ox-it/rabbitmq-auth-mechanism-gssapi) that it works with, but as far as I know that's the only server-side implementation (qpid does GSSAPI, but that's AMQP 1.0).

I also know that SASL is a potentially multi-step process, whereas this implementation only supports a single step.
