### PR TITLE
CI: Add pypy3 to allowed_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ env:
     - TOXENV=flakeplus
     - TOXENV=pydocstyle
     - TOXENV=apicheck
+
+matrix:
+  allow_failures:
+    - env: TOXENV=pypy3
+  fast_finish: true
+
 install: travis_retry pip install -U tox
 script: tox -v -- -v
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - TOXENV=3.4
     - TOXENV=pypy
     - TOXENV=3.5
+    - TOXENV=pypy3
     - TOXENV=flake8
     - TOXENV=flakeplus
     - TOXENV=pydocstyle

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     pypy
     3.4
     3.5
+    pypy3
     flake8
     flakeplus
     apicheck
@@ -26,6 +27,7 @@ basepython =
     3.4: python3.4
     3.5: python3.5
     pypy: pypy
+    pypy3: pypy3
 
 [testenv:apicheck]
 commands =


### PR DESCRIPTION
This way it can enabled later again when pypy3.3 v5.5 is added to travis.