### PR TITLE
Pass fmt string as a str object to struct functions (#112)

### DIFF
--- a/amqp/exceptions.py
+++ b/amqp/exceptions.py
@@ -296,5 +296,5 @@ METHOD_NAME_MAP = {
 
 
 for _method_id, _method_name in list(METHOD_NAME_MAP.items()):
-    METHOD_NAME_MAP[unpack(b'>I', pack(b'>HH', *_method_id))[0]] = \
+    METHOD_NAME_MAP[unpack(str('>I'), pack(str('>HH'), *_method_id))[0]] = \
         _method_name

--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -56,7 +56,7 @@ def frame_handler(connection, callback,
                     frame_type, expected_types[channel]),
             )
         elif frame_type == 1:
-            method_sig = unpack_from(b'>HH', buf, 0)
+            method_sig = unpack_from(str('>HH'), buf, 0)
 
             if method_sig in content_methods:
                 # Save what we've got so far and wait for the content-header
@@ -126,48 +126,48 @@ def frame_writer(connection, transport,
 
         if bigbody:
             # ## SLOW: string copy and write for every frame
-            frame = (b''.join([pack(b'>HH', *method_sig), args])
+            frame = (b''.join([pack(str('>HH'), *method_sig), args])
                      if type_ == 1 else b'')  # encode method frame
             framelen = len(frame)
-            write(pack((str('>BHI%dsB') % framelen).encode(),
+            write(pack(str('>BHI%dsB') % framelen,
                        type_, channel, framelen, frame, 0xce))
             if body:
                 frame = b''.join([
-                    pack(b'>HHQ', method_sig[0], 0, len(body)),
+                    pack(str('>HHQ'), method_sig[0], 0, len(body)),
                     properties,
                 ])
                 framelen = len(frame)
-                write(pack((str('>BHI%dsB') % framelen).encode(),
+                write(pack(str('>BHI%dsB') % framelen,
                            2, channel, framelen, frame, 0xce))
 
                 for i in range(0, bodylen, chunk_size):
                     frame = body[i:i + chunk_size]
                     framelen = len(frame)
-                    write(pack((str('>BHI%dsB') % framelen).encode(),
+                    write(pack(str('>BHI%dsB') % framelen,
                                3, channel, framelen,
                                str_to_bytes(frame), 0xce))
 
         else:
             # ## FAST: pack into buffer and single write
-            frame = (b''.join([pack(b'>HH', *method_sig), args])
+            frame = (b''.join([pack(str('>HH'), *method_sig), args])
                      if type_ == 1 else b'')
             framelen = len(frame)
-            pack_into((str('>BHI%dsB') % framelen).encode(), buf, offset,
+            pack_into(str('>BHI%dsB') % framelen, buf, offset,
                       type_, channel, framelen, frame, 0xce)
             offset += 8 + framelen
             if body:
                 frame = b''.join([
-                    pack(b'>HHQ', method_sig[0], 0, len(body)),
+                    pack(str('>HHQ'), method_sig[0], 0, len(body)),
                     properties,
                 ])
                 framelen = len(frame)
 
-                pack_into((str('>BHI%dsB') % framelen).encode(), buf, offset,
+                pack_into(str('>BHI%dsB') % framelen, buf, offset,
                           2, channel, framelen, frame, 0xce)
                 offset += 8 + framelen
 
                 framelen = len(body)
-                pack_into((str('>BHI%dsB') % framelen).encode(), buf, offset,
+                pack_into(str('>BHI%dsB') % framelen, buf, offset,
                           3, channel, framelen, str_to_bytes(body), 0xce)
                 offset += 8 + framelen
 

--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -54,78 +54,78 @@ def _read_item(buf, offset=0, unpack_from=unpack_from, ftype_t=ftype_t):
 
     # 'S': long string
     if ftype == 'S':
-        slen, = unpack_from(b'>I', buf, offset)
+        slen, = unpack_from(str('>I'), buf, offset)
         offset += 4
         val = pstr_t(buf[offset:offset + slen])
         offset += slen
     # 's': short string
     elif ftype == 's':
-        slen, = unpack_from(b'>B', buf, offset)
+        slen, = unpack_from(str('>B'), buf, offset)
         offset += 1
         val = pstr_t(buf[offset:offset + slen])
         offset += slen
     # 'b': short-short int
     elif ftype == 'b':
-        val, = unpack_from(b'>B', buf, offset)
+        val, = unpack_from(str('>B'), buf, offset)
         offset += 1
     # 'B': short-short unsigned int
     elif ftype == 'B':
-        val, = unpack_from(b'>b', buf, offset)
+        val, = unpack_from(str('>b'), buf, offset)
         offset += 1
     # 'U': short int
     elif ftype == 'U':
-        val, = unpack_from(b'>h', buf, offset)
+        val, = unpack_from(str('>h'), buf, offset)
         offset += 2
     # 'u': short unsigned int
     elif ftype == 'u':
-        val, = unpack_from(b'>H', buf, offset)
+        val, = unpack_from(str('>H'), buf, offset)
         offset += 2
     # 'I': long int
     elif ftype == 'I':
-        val, = unpack_from(b'>i', buf, offset)
+        val, = unpack_from(str('>i'), buf, offset)
         offset += 4
     # 'i': long unsigned int
     elif ftype == 'i':
-        val, = unpack_from(b'>I', buf, offset)
+        val, = unpack_from(str('>I'), buf, offset)
         offset += 4
     # 'L': long long int
     elif ftype == 'L':
-        val, = unpack_from(b'>q', buf, offset)
+        val, = unpack_from(str('>q'), buf, offset)
         offset += 8
     # 'l': long long unsigned int
     elif ftype == 'l':
-        val, = unpack_from(b'>Q', buf, offset)
+        val, = unpack_from(str('>Q'), buf, offset)
         offset += 8
     # 'f': float
     elif ftype == 'f':
-        val, = unpack_from(b'>f', buf, offset)
+        val, = unpack_from(str('>f'), buf, offset)
         offset += 4
     # 'd': double
     elif ftype == 'd':
-        val, = unpack_from(b'>d', buf, offset)
+        val, = unpack_from(str('>d'), buf, offset)
         offset += 8
     # 'D': decimal
     elif ftype == 'D':
-        d, = unpack_from(b'>B', buf, offset)
+        d, = unpack_from(str('>B'), buf, offset)
         offset += 1
-        n, = unpack_from(b'>i', buf, offset)
+        n, = unpack_from(str('>i'), buf, offset)
         offset += 4
         val = Decimal(n) / Decimal(10 ** d)
     # 'F': table
     elif ftype == 'F':
-        tlen, = unpack_from(b'>I', buf, offset)
+        tlen, = unpack_from(str('>I'), buf, offset)
         offset += 4
         limit = offset + tlen
         val = {}
         while offset < limit:
-            keylen, = unpack_from(b'>B', buf, offset)
+            keylen, = unpack_from(str('>B'), buf, offset)
             offset += 1
             key = pstr_t(buf[offset:offset + keylen])
             offset += keylen
             val[key], offset = _read_item(buf, offset)
     # 'A': array
     elif ftype == 'A':
-        alen, = unpack_from(b'>I', buf, offset)
+        alen, = unpack_from(str('>I'), buf, offset)
         offset += 4
         limit = offset + alen
         val = []
@@ -134,12 +134,12 @@ def _read_item(buf, offset=0, unpack_from=unpack_from, ftype_t=ftype_t):
             val.append(v)
     # 't' (bool)
     elif ftype == 't':
-        val, = unpack_from(b'>B', buf, offset)
+        val, = unpack_from(str('>B'), buf, offset)
         val = bool(val)
         offset += 1
     # 'T': timestamp
     elif ftype == 'T':
-        val, = unpack_from(b'>Q', buf, offset)
+        val, = unpack_from(str('>Q'), buf, offset)
         offset += 8
         val = datetime.utcfromtimestamp(val)
     # 'V': void
@@ -186,51 +186,51 @@ def loads(format, buf, offset=0,
             offset += 1
         elif p == 'o':
             bitcount = bits = 0
-            val, = unpack_from(b'>B', buf, offset)
+            val, = unpack_from(str('>B'), buf, offset)
             offset += 1
         elif p == 'B':
             bitcount = bits = 0
-            val, = unpack_from(b'>H', buf, offset)
+            val, = unpack_from(str('>H'), buf, offset)
             offset += 2
         elif p == 'l':
             bitcount = bits = 0
-            val, = unpack_from(b'>I', buf, offset)
+            val, = unpack_from(str('>I'), buf, offset)
             offset += 4
         elif p == 'L':
             bitcount = bits = 0
-            val, = unpack_from(b'>Q', buf, offset)
+            val, = unpack_from(str('>Q'), buf, offset)
             offset += 8
         elif p == 'f':
             bitcount = bits = 0
-            val, = unpack_from(b'>f', buf, offset)
+            val, = unpack_from(str('>f'), buf, offset)
             offset += 4
         elif p == 's':
             bitcount = bits = 0
-            slen, = unpack_from(b'B', buf, offset)
+            slen, = unpack_from(str('B'), buf, offset)
             offset += 1
             val = buf[offset:offset + slen].decode('utf-8')
             offset += slen
         elif p == 'S':
             bitcount = bits = 0
-            slen, = unpack_from(b'>I', buf, offset)
+            slen, = unpack_from(str('>I'), buf, offset)
             offset += 4
             val = buf[offset:offset + slen].decode('utf-8')
             offset += slen
         elif p == 'F':
             bitcount = bits = 0
-            tlen, = unpack_from(b'>I', buf, offset)
+            tlen, = unpack_from(str('>I'), buf, offset)
             offset += 4
             limit = offset + tlen
             val = {}
             while offset < limit:
-                keylen, = unpack_from(b'>B', buf, offset)
+                keylen, = unpack_from(str('>B'), buf, offset)
                 offset += 1
                 key = pstr_t(buf[offset:offset + keylen])
                 offset += keylen
                 val[key], offset = _read_item(buf, offset)
         elif p == 'A':
             bitcount = bits = 0
-            alen, = unpack_from(b'>I', buf, offset)
+            alen, = unpack_from(str('>I'), buf, offset)
             offset += 4
             limit = offset + alen
             val = []
@@ -239,7 +239,7 @@ def loads(format, buf, offset=0,
                 val.append(aval)
         elif p == 'T':
             bitcount = bits = 0
-            val, = unpack_from(b'>Q', buf, offset)
+            val, = unpack_from(str('>Q'), buf, offset)
             offset += 8
             val = datetime.utcfromtimestamp(val)
         else:
@@ -250,7 +250,7 @@ def loads(format, buf, offset=0,
 
 def _flushbits(bits, write, pack=pack):
     if bits:
-        write(pack(b'B' * len(bits), *bits))
+        write(pack(str('B') * len(bits), *bits))
         bits[:] = []
     return 0
 
@@ -287,32 +287,32 @@ def dumps(format, values):
             bitcount += 1
         elif p == 'o':
             bitcount = _flushbits(bits, write)
-            write(pack(b'B', val))
+            write(pack(str('B'), val))
         elif p == 'B':
             bitcount = _flushbits(bits, write)
-            write(pack(b'>H', int(val)))
+            write(pack(str('>H'), int(val)))
         elif p == 'l':
             bitcount = _flushbits(bits, write)
-            write(pack(b'>I', val))
+            write(pack(str('>I'), val))
         elif p == 'L':
             bitcount = _flushbits(bits, write)
-            write(pack(b'>Q', val))
+            write(pack(str('>Q'), val))
         elif p == 'f':
             bitcount = _flushbits(bits, write)
-            write(pack(b'>f', val))
+            write(pack(str('>f'), val))
         elif p == 's':
             val = val or ''
             bitcount = _flushbits(bits, write)
             if isinstance(val, string):
                 val = val.encode('utf-8')
-            write(pack(b'B', len(val)))
+            write(pack(str('B'), len(val)))
             write(val)
         elif p == 'S':
             val = val or ''
             bitcount = _flushbits(bits, write)
             if isinstance(val, string):
                 val = val.encode('utf-8')
-            write(pack(b'>I', len(val)))
+            write(pack(str('>I'), len(val)))
             write(val)
         elif p == 'F':
             bitcount = _flushbits(bits, write)
@@ -321,7 +321,7 @@ def dumps(format, values):
             bitcount = _flushbits(bits, write)
             _write_array(val or [], write, bits)
         elif p == 'T':
-            write(pack(b'>Q', long_t(calendar.timegm(val.utctimetuple()))))
+            write(pack(str('>Q'), long_t(calendar.timegm(val.utctimetuple()))))
     _flushbits(bits, write)
 
     return out.getvalue()
@@ -333,7 +333,7 @@ def _write_table(d, write, bits, pack=pack):
     for k, v in items(d):
         if isinstance(k, string):
             k = k.encode('utf-8')
-        twrite(pack(b'B', len(k)))
+        twrite(pack(str('B'), len(k)))
         twrite(k)
         try:
             _write_item(v, twrite, bits)
@@ -341,7 +341,7 @@ def _write_table(d, write, bits, pack=pack):
             raise FrameSyntaxError(
                 ILLEGAL_TABLE_TYPE_WITH_KEY.format(type(v), k, v))
     table_data = out.getvalue()
-    write(pack(b'>I', len(table_data)))
+    write(pack(str('>I'), len(table_data)))
     write(table_data)
 
 
@@ -355,7 +355,7 @@ def _write_array(l, write, bits, pack=pack):
             raise FrameSyntaxError(
                 ILLEGAL_TABLE_TYPE_WITH_VALUE.format(type(v), v))
     array_data = out.getvalue()
-    write(pack(b'>I', len(array_data)))
+    write(pack(str('>I'), len(array_data)))
     write(array_data)
 
 
@@ -367,17 +367,17 @@ def _write_item(v, write, bits, pack=pack,
     if isinstance(v, (string_t, bytes)):
         if isinstance(v, string):
             v = v.encode('utf-8')
-        write(pack(b'>cI', b'S', len(v)))
+        write(pack(str('>cI'), b'S', len(v)))
         write(v)
     elif isinstance(v, bool):
-        write(pack(b'>cB', b't', int(v)))
+        write(pack(str('>cB'), b't', int(v)))
     elif isinstance(v, float):
-        write(pack(b'>cd', b'd', v))
+        write(pack(str('>cd'), b'd', v))
     elif isinstance(v, int_types):
         if v > 2147483647 or v < -2147483647:
-            write(pack(b'>cq', b'L', v))
+            write(pack(str('>cq'), b'L', v))
         else:
-            write(pack(b'>ci', b'I', v))
+            write(pack(str('>ci'), b'I', v))
     elif isinstance(v, Decimal):
         sign, digits, exponent = v.as_tuple()
         v = 0
@@ -385,9 +385,10 @@ def _write_item(v, write, bits, pack=pack,
             v = (v * 10) + d
         if sign:
             v = -v
-        write(pack(b'>cBi', b'D', -exponent, v))
+        write(pack(str('>cBi'), b'D', -exponent, v))
     elif isinstance(v, datetime):
-        write(pack(b'>cQ', b'T', long_t(calendar.timegm(v.utctimetuple()))))
+        write(
+            pack(str('>cQ'), b'T', long_t(calendar.timegm(v.utctimetuple()))))
     elif isinstance(v, dict):
         write(b'F')
         _write_table(v, write, bits)
@@ -405,16 +406,16 @@ def decode_properties_basic(buf, offset=0,
     """Decode basic properties."""
     properties = {}
 
-    flags, = unpack_from(b'>H', buf, offset)
+    flags, = unpack_from(str('>H'), buf, offset)
     offset += 2
 
     if flags & 0x8000:
-        slen, = unpack_from(b'>B', buf, offset)
+        slen, = unpack_from(str('>B'), buf, offset)
         offset += 1
         properties['content_type'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x4000:
-        slen, = unpack_from(b'>B', buf, offset)
+        slen, = unpack_from(str('>B'), buf, offset)
         offset += 1
         properties['content_encoding'] = pstr_t(buf[offset:offset + slen])
         offset += slen
@@ -422,51 +423,51 @@ def decode_properties_basic(buf, offset=0,
         _f, offset = loads('F', buf, offset)
         properties['application_headers'], = _f
     if flags & 0x1000:
-        properties['delivery_mode'], = unpack_from(b'>B', buf, offset)
+        properties['delivery_mode'], = unpack_from(str('>B'), buf, offset)
         offset += 1
     if flags & 0x0800:
-        properties['priority'], = unpack_from(b'>B', buf, offset)
+        properties['priority'], = unpack_from(str('>B'), buf, offset)
         offset += 1
     if flags & 0x0400:
-        slen, = unpack_from(b'>B', buf, offset)
+        slen, = unpack_from(str('>B'), buf, offset)
         offset += 1
         properties['correlation_id'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0200:
-        slen, = unpack_from(b'>B', buf, offset)
+        slen, = unpack_from(str('>B'), buf, offset)
         offset += 1
         properties['reply_to'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0100:
-        slen, = unpack_from(b'>B', buf, offset)
+        slen, = unpack_from(str('>B'), buf, offset)
         offset += 1
         properties['expiration'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0080:
-        slen, = unpack_from(b'>B', buf, offset)
+        slen, = unpack_from(str('>B'), buf, offset)
         offset += 1
         properties['message_id'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0040:
-        properties['timestamp'], = unpack_from(b'>Q', buf, offset)
+        properties['timestamp'], = unpack_from(str('>Q'), buf, offset)
         offset += 8
     if flags & 0x0020:
-        slen, = unpack_from(b'>B', buf, offset)
+        slen, = unpack_from(str('>B'), buf, offset)
         offset += 1
         properties['type'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0010:
-        slen, = unpack_from(b'>B', buf, offset)
+        slen, = unpack_from(str('>B'), buf, offset)
         offset += 1
         properties['user_id'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0008:
-        slen, = unpack_from(b'>B', buf, offset)
+        slen, = unpack_from(str('>B'), buf, offset)
         offset += 1
         properties['app_id'] = pstr_t(buf[offset:offset + slen])
         offset += slen
     if flags & 0x0004:
-        slen, = unpack_from(b'>B', buf, offset)
+        slen, = unpack_from(str('>B'), buf, offset)
         offset += 1
         properties['cluster_id'] = pstr_t(buf[offset:offset + slen])
         offset += slen
@@ -552,13 +553,13 @@ class GenericContent(object):
         result = BytesIO()
         write = result.write
         for flag_bits in flags:
-            write(pack(b'>H', flag_bits))
+            write(pack(str('>H'), flag_bits))
         write(dumps(b''.join(sformat), svalues))
 
         return result.getvalue()
 
     def inbound_header(self, buf, offset=0):
-        class_id, self.body_size = unpack_from(b'>HxxQ', buf, offset)
+        class_id, self.body_size = unpack_from(str('>HxxQ'), buf, offset)
         offset += 12
         self._load_properties(class_id, buf, offset)
         if not self.body_size:

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -162,7 +162,7 @@ class _AbstractTransport(object):
                 if interval is not None:
                     self.sock.setsockopt(
                         socket.SOL_SOCKET, timeout,
-                        struct.pack(b'll', interval, 0),
+                        struct.pack(str('ll'), interval, 0),
                     )
             self._setup_transport()
 
@@ -230,7 +230,7 @@ class _AbstractTransport(object):
         try:
             frame_header = read(7, True)
             read_frame_buffer += frame_header
-            frame_type, channel, size = unpack(b'>BHI', frame_header)
+            frame_type, channel, size = unpack(str('>BHI'), frame_header)
             # >I is an unsigned int, but the argument to sock.recv is signed,
             # so we know the size can be at most 2 * SIGNED_INT_MAX
             if size > SIGNED_INT_MAX:

--- a/t/unit/test_method_framing.py
+++ b/t/unit/test_method_framing.py
@@ -22,21 +22,21 @@ class test_frame_handler:
         self.g = frame_handler(self.conn, self.callback)
 
     def test_header(self):
-        buf = pack(b'>HH', 60, 51)
+        buf = pack(str('>HH'), 60, 51)
         self.g((1, 1, buf))
         self.callback.assert_called_with(1, (60, 51), buf, None)
         assert self.conn.bytes_recv
 
     def test_header_message_empty_body(self):
-        self.g((1, 1, pack(b'>HH', *spec.Basic.Deliver)))
+        self.g((1, 1, pack(str('>HH'), *spec.Basic.Deliver)))
         self.callback.assert_not_called()
 
         with pytest.raises(UnexpectedFrame):
-            self.g((1, 1, pack(b'>HH', *spec.Basic.Deliver)))
+            self.g((1, 1, pack(str('>HH'), *spec.Basic.Deliver)))
 
         m = Message()
         m.properties = {}
-        buf = pack(b'>HxxQ', m.CLASS_ID, 0)
+        buf = pack(str('>HxxQ'), m.CLASS_ID, 0)
         buf += m._serialize_properties()
         self.g((2, 1, buf))
 
@@ -47,12 +47,12 @@ class test_frame_handler:
         )
 
     def test_header_message_content(self):
-        self.g((1, 1, pack(b'>HH', *spec.Basic.Deliver)))
+        self.g((1, 1, pack(str('>HH'), *spec.Basic.Deliver)))
         self.callback.assert_not_called()
 
         m = Message()
         m.properties = {}
-        buf = pack(b'>HxxQ', m.CLASS_ID, 16)
+        buf = pack(str('>HxxQ'), m.CLASS_ID, 16)
         buf += m._serialize_properties()
         self.g((2, 1, buf))
         self.callback.assert_not_called()

--- a/t/unit/test_serialization.py
+++ b/t/unit/test_serialization.py
@@ -25,14 +25,14 @@ class test_serialization:
 
     @pytest.mark.parametrize('descr,frame,expected,cast', [
         ('S', b's8thequick', 'thequick', None),
-        ('b', b'b' + pack(b'>B', True), True, None),
-        ('B', b'B' + pack(b'>b', 123), 123, None),
-        ('U', b'U' + pack(b'>h', -321), -321, None),
-        ('u', b'u' + pack(b'>H', 321), 321, None),
-        ('i', b'i' + pack(b'>I', 1234), 1234, None),
-        ('L', b'L' + pack(b'>q', -32451), -32451, None),
-        ('l', b'l' + pack(b'>Q', 32451), 32451, None),
-        ('f', b'f' + pack(b'>f', 33.3), 34.0, ceil),
+        ('b', b'b' + pack(str('>B'), True), True, None),
+        ('B', b'B' + pack(str('>b'), 123), 123, None),
+        ('U', b'U' + pack(str('>h'), -321), -321, None),
+        ('u', b'u' + pack(str('>H'), 321), 321, None),
+        ('i', b'i' + pack(str('>I'), 1234), 1234, None),
+        ('L', b'L' + pack(str('>q'), -32451), -32451, None),
+        ('l', b'l' + pack(str('>Q'), 32451), 32451, None),
+        ('f', b'f' + pack(str('>f'), 33.3), 34.0, ceil),
     ])
     def test_read_item(self, descr, frame, expected, cast):
         actual = _read_item(frame)[0]
@@ -162,7 +162,7 @@ class test_GenericContent:
             'content_encoding': 'utf-8',
         }
         body = 'the quick brown fox'
-        buf = b'\0' * 30 + pack(b'>HxxQ', m.CLASS_ID, len(body))
+        buf = b'\0' * 30 + pack(str('>HxxQ'), m.CLASS_ID, len(body))
         buf += m._serialize_properties()
         assert m.inbound_header(buf, offset=30) == 42
         assert m.body_size == len(body)
@@ -172,7 +172,7 @@ class test_GenericContent:
     def test_inbound_header__empty_body(self):
         m = Message()
         m.properties = {}
-        buf = pack(b'>HxxQ', m.CLASS_ID, 0)
+        buf = pack(str('>HxxQ'), m.CLASS_ID, 0)
         buf += m._serialize_properties()
         assert m.inbound_header(buf, offset=0) == 12
         assert m.ready

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -264,11 +264,11 @@ class test_AbstractTransport:
             self.t._read.return_value = b'thequickbrownfox'
             self.t._read.side_effect = on_read2
             return ret
-        self.t._read.return_value = pack(b'>BHI', 1, 1, 16)
+        self.t._read.return_value = pack(str('>BHI'), 1, 1, 16)
         self.t._read.side_effect = on_read1
 
         self.t.read_frame()
-        self.t._read.return_value = pack(b'>BHI', 1, 1, 16)
+        self.t._read.return_value = pack(str('>BHI'), 1, 1, 16)
         self.t._read.side_effect = on_read1
         checksum[0] = b'\x13'
         with pytest.raises(UnexpectedFrame):


### PR DESCRIPTION
@ask This is intended to fix the use of the `struct` module in a way that is compatible with both Python 2 and 3 and doesn't produce any spurious warnings.

In Python 3, mixing `bytes` and `str` as the format argument for `struct` functions produces `BytesWarning`s. See the typeshed discussion, <https://github.com/python/typeshed/pull/669>

Per the [docs](https://docs.python.org/3/library/struct.html#format-strings), the format arg is a string (`str`), not bytes.