### PR TITLE
do not reconnect on collect

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -418,7 +418,7 @@ class Connection(AbstractChannel):
 
     def collect(self):
         try:
-            self.transport.close()
+            self._transport.close()
 
             temp_list = [x for x in values(self.channels) if x is not self]
             for ch in temp_list:

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -418,7 +418,8 @@ class Connection(AbstractChannel):
 
     def collect(self):
         try:
-            self._transport.close()
+            if self._transport:
+                self._transport.close()
 
             temp_list = [x for x in values(self.channels) if x is not self]
             for ch in temp_list:

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -171,6 +171,13 @@ class test_Connection:
         self.conn.channels[1].collect.side_effect = socket.error()
         self.conn.collect()
 
+    def test_collect_no_transport(self):
+        self.conn = Connection()
+        self.conn.connect = Mock(name='connect')
+        assert not self.conn.connected
+        self.conn.collect()
+        assert not self.conn.connect.called
+
     def test_get_free_channel_id__raises_IndexError(self):
         self.conn._avail_channel_ids = []
         with pytest.raises(ResourceError):


### PR DESCRIPTION
collect is called to cleanup when there is a connection error but
the backward compatibility code to connect when transport is called
gets triggered. this doesn't seem right as this should be handled by
ensure_connection.