### PR TITLE
On Windows work around setsockopt error in transport. 

### DIFF
--- a/amqp/platform.py
+++ b/amqp/platform.py
@@ -41,6 +41,17 @@ except ImportError:  # pragma: no cover
     TCP_USER_TIMEOUT = 18
     HAS_TCP_USER_TIMEOUT = LINUX_VERSION and LINUX_VERSION >= (2, 6, 37)
 
+WIN_VERSION = None
+if sys.platform.startswith('win32'):
+    WIN_VERSION = sys.getwindowsversion()
+
+# On Windows TCP_OPTS will include TCP_NODELAY (value of 1) and
+# TCP_KEEPIDLE (value of 4). Calls to getsockopt and setsockopt with
+# level of IPPROTO_TCP (SOL_TCP) only accept TCP_NODELAY however,
+# and instead interpret TCP_KEEPIDLE as SO_REUSEADDR. Calls to
+# setsockopt with IPPROTO_TCP, SO_REUSEADDR will fail with Windows
+# error 10042 WSAENOPROTOOPT.
+LIMITED_TCP_OPTS = WIN_VERSION is not None
 
 if sys.version_info < (2, 7, 6):
     import functools
@@ -63,9 +74,11 @@ else:
 
 __all__ = [
     'LINUX_VERSION',
+    'WIN_VERSION',
     'SOL_TCP',
     'TCP_USER_TIMEOUT',
     'HAS_TCP_USER_TIMEOUT',
+    'LIMITED_TCP_OPTS',
     'pack',
     'pack_into',
     'unpack',

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -26,7 +26,7 @@ from contextlib import contextmanager
 from .exceptions import UnexpectedFrame
 from .five import items
 from .platform import (
-    SOL_TCP, TCP_USER_TIMEOUT, HAS_TCP_USER_TIMEOUT,
+    SOL_TCP, TCP_USER_TIMEOUT, HAS_TCP_USER_TIMEOUT, LIMITED_TCP_OPTS,
     pack, unpack,
 )
 from .utils import get_errno, set_cloexec
@@ -52,15 +52,21 @@ AMQP_PROTOCOL_HEADER = 'AMQP\x01\x01\x00\x09'.encode('latin_1')
 IPV6_LITERAL = re.compile(r'\[([\.0-9a-f:]+)\](?::(\d+))?')
 
 # available socket options for TCP level
-KNOWN_TCP_OPTS = (
-    'TCP_CORK', 'TCP_DEFER_ACCEPT', 'TCP_KEEPCNT',
-    'TCP_KEEPIDLE', 'TCP_KEEPINTVL', 'TCP_LINGER2',
-    'TCP_MAXSEG', 'TCP_NODELAY', 'TCP_QUICKACK',
-    'TCP_SYNCNT', 'TCP_WINDOW_CLAMP',
-)
+
+if LIMITED_TCP_OPTS:
+    KNOWN_TCP_OPTS = ('TCP_NODELAY',)
+else:
+    KNOWN_TCP_OPTS = (
+        'TCP_CORK', 'TCP_DEFER_ACCEPT', 'TCP_KEEPCNT',
+        'TCP_KEEPIDLE', 'TCP_KEEPINTVL', 'TCP_LINGER2',
+        'TCP_MAXSEG', 'TCP_NODELAY', 'TCP_QUICKACK',
+        'TCP_SYNCNT', 'TCP_WINDOW_CLAMP',
+    )
+
 TCP_OPTS = {
     getattr(socket, opt) for opt in KNOWN_TCP_OPTS if hasattr(socket, opt)
 }
+
 DEFAULT_SOCKET_SETTINGS = {
     socket.TCP_NODELAY: 1,
 }


### PR DESCRIPTION
On Windows TCP_OPTS will include TCP_NODELAY (value of 1) and TCP_KEEPIDLE (value of 4). Calls to getsockopt and setsockopt with level of IPPROTO_TCP (SOL_TCP) only accept TCP_NODELAY however, and instead interpret TCP_KEEPIDLE as SO_REUSEADDR. Calls to setsockopt with IPPROTO_TCP, SO_REUSEADDR will fail with Windows error 10042 WSAENOPROTOOPT.

This change modifies platform to expose the windows version, and using that version a variable to limit tcp opts. Transport is modified to respect this variable, on windows only listing TCP_NODELAY.