### PR TITLE
don't fail if collect already called

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -437,7 +437,8 @@ class Connection(AbstractChannel):
             if self._transport:
                 self._transport.close()
 
-            temp_list = [x for x in values(self.channels) if x is not self]
+            temp_list = [x for x in values(self.channels or {})
+                         if x is not self]
             for ch in temp_list:
                 ch.collect()
         except socket.error:

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -232,6 +232,11 @@ class test_Connection:
         self.conn.collect()
         assert not self.conn.connect.called
 
+    def test_collect_again(self):
+        self.conn = Connection()
+        self.conn.collect()
+        self.conn.collect()
+
     def test_get_free_channel_id__raises_IndexError(self):
         self.conn._avail_channel_ids = []
         with pytest.raises(ResourceError):


### PR DESCRIPTION
avoid AttributeError if collect is called and no channels exist.
can occur if collect called twice.