### PR TITLE
Issue #125 - Cannot import amqp with Python-2.7.6

### DIFF
--- a/amqp/platform.py
+++ b/amqp/platform.py
@@ -42,7 +42,7 @@ except ImportError:  # pragma: no cover
     HAS_TCP_USER_TIMEOUT = LINUX_VERSION and LINUX_VERSION >= (2, 6, 37)
 
 
-if sys.version_info < (2, 7, 6):
+if sys.version_info < (2, 7, 7):
     import functools
 
     def _to_bytes_arg(fun):

--- a/t/unit/test_platform.py
+++ b/t/unit/test_platform.py
@@ -3,6 +3,11 @@ import pytest
 from amqp.platform import _linux_version_to_tuple
 
 
+def test_struct_argument_type():
+    from amqp.exceptions import FrameSyntaxError
+    FrameSyntaxError()
+
+
 @pytest.mark.parametrize('s,expected', [
     ('3.13.0-46-generic', (3, 13, 0)),
     ('3.19.43-1-amd64', (3, 19, 43)),


### PR DESCRIPTION
Fixes celery/py-amqp#125

* changed python version check to < 2.7.7 so compatibility code will execute for 2.7.6
* added test to ensure expected behavior