### PR TITLE
win32: TCP_MAXSEG isn't available for setsockopt

### DIFF
--- a/amqp/platform.py
+++ b/amqp/platform.py
@@ -41,6 +41,12 @@ except ImportError:  # pragma: no cover
     TCP_USER_TIMEOUT = 18
     HAS_TCP_USER_TIMEOUT = LINUX_VERSION and LINUX_VERSION >= (2, 6, 37)
 
+HAS_TCP_MAXSEG = True
+# According to MSDN Windows platforms support getsockopt(TCP_MAXSSEG) but not
+# setsockopt(TCP_MAXSEG) on IPPROTO_TCP sockets.
+if sys.platform.startswith('win'):
+    HAS_TCP_MAXSEG = False
+
 
 if sys.version_info < (2, 7, 6):
     import functools
@@ -66,6 +72,7 @@ __all__ = [
     'SOL_TCP',
     'TCP_USER_TIMEOUT',
     'HAS_TCP_USER_TIMEOUT',
+    'HAS_TCP_MAXSEG',
     'pack',
     'pack_into',
     'unpack',

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -26,7 +26,7 @@ from contextlib import contextmanager
 from .exceptions import UnexpectedFrame
 from .five import items
 from .platform import (
-    SOL_TCP, TCP_USER_TIMEOUT, HAS_TCP_USER_TIMEOUT,
+    SOL_TCP, TCP_USER_TIMEOUT, HAS_TCP_USER_TIMEOUT, HAS_TCP_MAXSEG,
     pack, unpack,
 )
 from .utils import get_errno, set_cloexec
@@ -55,9 +55,13 @@ IPV6_LITERAL = re.compile(r'\[([\.0-9a-f:]+)\](?::(\d+))?')
 KNOWN_TCP_OPTS = (
     'TCP_CORK', 'TCP_DEFER_ACCEPT', 'TCP_KEEPCNT',
     'TCP_KEEPIDLE', 'TCP_KEEPINTVL', 'TCP_LINGER2',
-    'TCP_MAXSEG', 'TCP_NODELAY', 'TCP_QUICKACK',
+    'TCP_NODELAY', 'TCP_QUICKACK',
     'TCP_SYNCNT', 'TCP_WINDOW_CLAMP',
 )
+
+if HAS_TCP_MAXSEG:
+    KNOWN_TCP_OPTS += ('TCP_MAXSEG', )
+
 TCP_OPTS = {
     getattr(socket, opt) for opt in KNOWN_TCP_OPTS if hasattr(socket, opt)
 }


### PR DESCRIPTION
According to [1,2] Windows platforms support getsockopt(TCP_MAXSSEG) but not setsockopt(TCP_MAXSEG) on IPPROTO_TCP sockets.  This results in:

socket.error: [Errno 10042] An unknown, invalid, or unsupported option or level was specified in a getsockopt or setsockopt call

when trying to connect to the server.

This is a latent issue uncovered by the refactor in:
    Set default KEEPIDLE/KEEPCNT/KEEPINTVL and TCP_USER_TIMEOUT (b14962c2dc)

[1] https://msdn.microsoft.com/en-us/library/windows/desktop/ms740476(v=vs.85).aspx
[2] https://msdn.microsoft.com/en-us/library/windows/desktop/ms738544(v=vs.85).aspx