### PR TITLE
Add support for setting the SNI hostname header

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -293,12 +293,28 @@ class SSLTransport(_AbstractTransport):
     def _wrap_socket(self, sock, context=None, **sslopts):
         if context:
             return self._wrap_context(sock, sslopts, **context)
-        return ssl.wrap_socket(sock, **sslopts)
+        return self._wrap_socket_sni(sock, **sslopts)
 
     def _wrap_context(self, sock, sslopts, check_hostname=None, **ctx_options):
         ctx = ssl.create_default_context(**ctx_options)
         ctx.check_hostname = check_hostname
         return ctx.wrap_socket(sock, **sslopts)
+
+    def _wrap_socket_sni(sock, keyfile=None, certfile=None,
+                         server_side=False, cert_reqs=ssl.CERT_NONE,
+                         ssl_version=ssl.PROTOCOL_TLS, ca_certs=None,
+                         do_handshake_on_connect=True,
+                         suppress_ragged_eofs=True,
+                         server_hostname=None,
+                         ciphers=None):
+        '''Default `ssl.wrap_socket` method augmented with support for
+        setting the server_hostname field required for SNI hostname header '''
+        return ssl.SSLSocket(sock=sock, keyfile=keyfile, certfile=certfile,
+                             server_side=server_side, cert_reqs=cert_reqs,
+                             ssl_version=ssl_version, ca_certs=ca_certs,
+                             do_handshake_on_connect=do_handshake_on_connect,
+                             suppress_ragged_eofs=suppress_ragged_eofs,
+                             server_hostname=server_hostname, ciphers=ciphers)
 
     def _shutdown_transport(self):
         """Unwrap a Python 2.6 SSL socket, so we can call shutdown()."""

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -307,8 +307,11 @@ class SSLTransport(_AbstractTransport):
                          suppress_ragged_eofs=True,
                          server_hostname=None,
                          ciphers=None):
-        '''Default `ssl.wrap_socket` method augmented with support for
-        setting the server_hostname field required for SNI hostname header '''
+        """Socket wrap with SNI headers
+
+        Default `ssl.wrap_socket` method augmented with support for
+        setting the server_hostname field required for SNI hostname header 
+        """
         return ssl.SSLSocket(sock=sock, keyfile=keyfile, certfile=certfile,
                              server_side=server_side, cert_reqs=cert_reqs,
                              ssl_version=ssl_version, ca_certs=ca_certs,

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -72,7 +72,7 @@ if HAS_TCP_USER_TIMEOUT:
 
 
 try:
-    from socket import TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT # noqa
+    from socket import TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT  # noqa
 except ImportError:
     pass
 else:
@@ -307,10 +307,10 @@ class SSLTransport(_AbstractTransport):
                          suppress_ragged_eofs=True,
                          server_hostname=None,
                          ciphers=None):
-        """Socket wrap with SNI headers
+        """Socket wrap with SNI headers.
 
         Default `ssl.wrap_socket` method augmented with support for
-        setting the server_hostname field required for SNI hostname header 
+        setting the server_hostname field required for SNI hostname header
         """
         return ssl.SSLSocket(sock=sock, keyfile=keyfile, certfile=certfile,
                              server_side=server_side, cert_reqs=cert_reqs,

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -302,7 +302,7 @@ class SSLTransport(_AbstractTransport):
 
     def _wrap_socket_sni(sock, keyfile=None, certfile=None,
                          server_side=False, cert_reqs=ssl.CERT_NONE,
-                         ssl_version=ssl.PROTOCOL_TLS, ca_certs=None,
+                         ssl_version=ssl.PROTOCOL_SSLv23, ca_certs=None,
                          do_handshake_on_connect=True,
                          suppress_ragged_eofs=True,
                          server_hostname=None,

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -312,12 +312,13 @@ class SSLTransport(_AbstractTransport):
         Default `ssl.wrap_socket` method augmented with support for
         setting the server_hostname field required for SNI hostname header
         """
-        return ssl.SSLSocket(sock=sock, keyfile=keyfile, certfile=certfile,
+        sock = ssl.SSLSocket(sock=sock, keyfile=keyfile, certfile=certfile,
                              server_side=server_side, cert_reqs=cert_reqs,
                              ssl_version=ssl_version, ca_certs=ca_certs,
                              do_handshake_on_connect=do_handshake_on_connect,
                              suppress_ragged_eofs=suppress_ragged_eofs,
                              server_hostname=server_hostname, ciphers=ciphers)
+        return sock
 
     def _shutdown_transport(self):
         """Unwrap a Python 2.6 SSL socket, so we can call shutdown()."""

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -323,7 +323,7 @@ class test_SSLTransport:
         self.t.sock.do_handshake.assert_called_with()
         assert self.t._quick_recv is self.t.sock.read
 
-    def test_wrap_socket(self, wrap_socket):
+    def test_wrap_socket(self):
         sock = Mock()
         self.t._wrap_context = Mock()
         self.t._wrap_socket_sni = Mock()

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -323,12 +323,12 @@ class test_SSLTransport:
         self.t.sock.do_handshake.assert_called_with()
         assert self.t._quick_recv is self.t.sock.read
 
-    @patch('ssl.wrap_socket')
     def test_wrap_socket(self, wrap_socket):
         sock = Mock()
         self.t._wrap_context = Mock()
+        self.t._wrap_socket_sni = Mock()
         self.t._wrap_socket(sock, foo=1)
-        wrap_socket.assert_called_with(sock, foo=1)
+        self.t._wrap_socket_sni.assert_called_with(sock, foo=1)
 
         self.t._wrap_socket(sock, {'c': 2}, foo=1)
         self.t._wrap_context.assert_called_with(sock, {'foo': 1}, c=2)


### PR DESCRIPTION
Replaces the default method `ssl.wrap_socket` with a patched one that supports passing in the server_hostname field. 
The _wrap_socket_sni method is based on the `ssl.wrap_socket` helper function (https://github.com/python/cpython/blob/2.7/Lib/ssl.py#L931) but adds in the extra `server_hostname` parameter that sets the required SNI headers. 