### PR TITLE
Use Logger.warning() as Logger.warn() is deprecated

### DIFF
--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -1604,7 +1604,7 @@ class Channel(AbstractChannel):
         try:
             fun = self.callbacks[consumer_tag]
         except KeyError:
-            AMQP_LOGGER.warn(
+            AMQP_LOGGER.warning(
                 REJECTED_MESSAGE_WITHOUT_CALLBACK,
                 delivery_tag, consumer_tag, exchange, routing_key,
             )


### PR DESCRIPTION
Fixes deprecation warning during tests:

```
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

https://docs.python.org/3/library/logging.html#logging.Logger.warning