### PR TITLE
Drain events should read until message is ready

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -479,7 +479,9 @@ class Connection(AbstractChannel):
         raise NotImplementedError('Use AMQP heartbeats')
 
     def drain_events(self, timeout=None):
-        return self.blocking_read(timeout)
+        # read until message is ready
+        while not self.blocking_read(timeout):
+            pass
 
     def blocking_read(self, timeout=None):
         with self.transport.having_timeout(timeout):

--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -64,9 +64,9 @@ def frame_handler(connection, callback,
                     frame_method=method_sig, frame_args=buf,
                 )
                 expected_types[channel] = 2
-            else:
-                callback(channel, method_sig, buf, None)
-            return False
+                return False
+
+            callback(channel, method_sig, buf, None)
 
         elif frame_type == 2:
             msg = partial_messages[channel]

--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -66,19 +66,22 @@ def frame_handler(connection, callback,
                 expected_types[channel] = 2
             else:
                 callback(channel, method_sig, buf, None)
+            return False
 
         elif frame_type == 2:
             msg = partial_messages[channel]
             msg.inbound_header(buf)
 
-            if msg.ready:
-                # bodyless message, we're done
-                expected_types[channel] = 1
-                partial_messages.pop(channel, None)
-                callback(channel, msg.frame_method, msg.frame_args, msg)
-            else:
+            if not msg.ready:
                 # wait for the content-body
                 expected_types[channel] = 3
+                return False
+
+            # bodyless message, we're done
+            expected_types[channel] = 1
+            partial_messages.pop(channel, None)
+            callback(channel, msg.frame_method, msg.frame_args, msg)
+
         elif frame_type == 3:
             msg = partial_messages[channel]
             msg.inbound_body(buf)
@@ -89,6 +92,7 @@ def frame_handler(connection, callback,
         elif frame_type == 8:
             # bytes_recv already updated
             pass
+        return True
 
     return on_frame
 

--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -5,4 +5,4 @@ flakeplus>=1.1
 tox>=2.3.1
 sphinx2rst>=1.0
 bumpversion
-pydocstyle
+pydocstyle==1.1.1


### PR DESCRIPTION
Related discussion: https://github.com/celery/kombu/pull/725 https://github.com/celery/celery/issues/3978 

Fixes issue introduced in celery 4.x https://github.com/celery/celery/issues/3978 https://github.com/celery/celery/issues/3737 https://github.com/celery/celery/issues/3814