### PR TITLE
Release notes for 2.2.0

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,45 @@ py-amqp is fork of amqplib used by Kombu containing additional features and impr
 The previous amqplib changelog is here:
 http://code.google.com/p/py-amqplib/source/browse/CHANGES
 
+.. _version-2.2.0
+
+2.2.0
+=====
+:release-date: TBD
+:release-by: Ask Solem
+
+- Fix random delays in task execusion.
+
+  This is a bug that caused performance issues due to polling timeouts that occur when receiving incomplete AMQP frames. (Issues #3978 #3737 #3814) 
+  
+  Fix contributed by **Robert Kopaczewski**
+
+- Calling ``conn.collect()`` multiple times will no longer raise an ``AttributeError`` when no channels exist.
+
+  Fix contributed by **Gord Chung**
+
+- Fix compatibility code for Python 2.7.6.
+
+  Fix contributed by **Jonathan Schuff**
+
+- When running in Windows, py-amqp will no longer use the unsupported TCP option TCP_MAXSEG.
+
+  Fix contributed by **Tony Breeds**
+  
+- Added support for setting the SNI hostname header.
+
+  The SSL protocol version is now set to SSLv23
+
+  Contributed by **Dhananjay Sathe**
+
+- Authentication mechanisms were refactored to be more modular. GSSAPI authentication is now supported.
+
+  Contributed by **Alexander Dutton**
+  
+- Do not reconnect on collect.
+
+  Fix contributed by **Gord Chung**
+
 .. _version-2.1.4:
 
 2.1.4

--- a/Changelog
+++ b/Changelog
@@ -12,10 +12,10 @@ http://code.google.com/p/py-amqplib/source/browse/CHANGES
 :release-date: TBD
 :release-by: Ask Solem
 
-- Fix random delays in task execusion.
+- Fix random delays in task execution.
 
-  This is a bug that caused performance issues due to polling timeouts that occur when receiving incomplete AMQP frames. (Issues #3978 #3737 #3814) 
-  
+  This is a bug that caused performance issues due to polling timeouts that occur when receiving incomplete AMQP frames. (Issues #3978 #3737 #3814)
+
   Fix contributed by **Robert Kopaczewski**
 
 - Calling ``conn.collect()`` multiple times will no longer raise an ``AttributeError`` when no channels exist.
@@ -29,7 +29,7 @@ http://code.google.com/p/py-amqplib/source/browse/CHANGES
 - When running in Windows, py-amqp will no longer use the unsupported TCP option TCP_MAXSEG.
 
   Fix contributed by **Tony Breeds**
-  
+
 - Added support for setting the SNI hostname header.
 
   The SSL protocol version is now set to SSLv23
@@ -39,7 +39,7 @@ http://code.google.com/p/py-amqplib/source/browse/CHANGES
 - Authentication mechanisms were refactored to be more modular. GSSAPI authentication is now supported.
 
   Contributed by **Alexander Dutton**
-  
+
 - Do not reconnect on collect.
 
   Fix contributed by **Gord Chung**


### PR DESCRIPTION
These are the release notes for 2.2.0. 
This release is going to be used for the upcoming Celery release.
The motivation behind the minor version bump is due to the authentication refactor which adds new capabilities but doesn't break backwards compatibility.

Please review and let me know if I got anything wrong.