### PR TITLE
Don't send AAAA DNS request when domain resolved to IPv4 address

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -180,7 +180,7 @@ class _AbstractTransport(object):
 
             # now that we have address(es) for the hostname, connect to broker
             for i, res in enumerate(entries):
-                af, socktype, proto, canonname, sa = res
+                af, socktype, proto, _, sa = res
                 try:
                     self.sock = socket.socket(af, socktype, proto)
                     try:

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -161,14 +161,16 @@ class _AbstractTransport(object):
         # or network connectivity problem), resolution process locks the
         # _connect call for extended time.
         addr_types = (socket.AF_INET, socket.AF_INET6)
+        addr_types_num = len(addr_types)
         for n, family in enumerate(addr_types):
             # first, resolve the address for a single address family
             try:
                 entries = socket.getaddrinfo(
                     host, port, family, socket.SOCK_STREAM, SOL_TCP)
+                entries_num = len(entries)
             except socket.gaierror:
                 # we may have depleted all our options
-                if n + 1 >= len(addr_types):
+                if n + 1 >= addr_types_num:
                     # if getaddrinfo succeeded before for another address
                     # family, reraise the previous socket.error since it's more
                     # relevant to users
@@ -194,7 +196,7 @@ class _AbstractTransport(object):
                         self.sock.close()
                         self.sock = None
                     # we may have depleted all our options
-                    if i + 1 >= len(entries) and n + 1 >= len(addr_types):
+                    if i + 1 >= entries_num and n + 1 >= addr_types_num:
                         raise
                 else:
                     # hurray, we established connection

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -174,7 +174,8 @@ class _AbstractTransport(object):
                     # relevant to users
                     raise (e
                            if e is not None
-                           else socket.error("failed to connect"))
+                           else socket.error(
+                               "failed to resolve broker hostname"))
                 continue
 
             # now that we have address(es) for the hostname, connect to broker

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -404,6 +404,16 @@ class test_AbstractTransport:
     def test_connect_getaddrinfo_raises_gaierror_once_recovers(self, *mocks):
         self.t.connect()
 
+    @patch('socket.socket', return_value=MockSocket())
+    @patch('socket.getaddrinfo',
+           return_value=[(socket.AF_INET, 1, socket.IPPROTO_TCP,
+                         '', ('127.0.0.1', 5672))])
+    def test_connect_survives_not_implemented_set_cloexec(self, *mocks):
+        with patch('amqp.transport.set_cloexec',
+                   side_effect=NotImplementedError) as cloexec_mock:
+            self.t.connect()
+        assert cloexec_mock.called
+
 
 class test_SSLTransport:
 

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -304,6 +304,31 @@ class test_AbstractTransport:
         with pytest.raises(socket.error):
             self.t.connect()
 
+    @patch('socket.socket.connect')
+    @patch('socket.getaddrinfo',
+           return_value=[
+               (2, 1, 6, '', ('127.0.0.1', 5672)),
+               (2, 1, 6, '', ('127.0.0.2', 5672))
+           ])
+    def test_connect_multiple_addr_entries_fails(self, getaddrinfo, connect):
+        self.t.sock = Mock()
+        self.t.close()
+        connect.side_effect = socket.error
+        with pytest.raises(socket.error):
+            self.t.connect()
+
+    @patch('socket.socket.connect')
+    @patch('socket.getaddrinfo',
+           return_value=[
+               (2, 1, 6, '', ('127.0.0.1', 5672)),
+               (2, 1, 6, '', ('127.0.0.2', 5672))
+           ])
+    def test_connect_multiple_addr_entries_succeed(self, getaddrinfo, connect):
+        self.t.sock = Mock()
+        self.t.close()
+        connect.side_effect = (socket.error, None)
+        self.t.connect()
+
 
 class test_SSLTransport:
 

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -389,6 +389,21 @@ class test_AbstractTransport:
             [call('localhost', 5672, addr_type, ANY, ANY)
              for addr_type in (socket.AF_INET, socket.AF_INET6)])
 
+    @patch('socket.getaddrinfo', side_effect=socket.gaierror)
+    def test_connect_getaddrinfo_raises_gaierror(self, getaddrinfo):
+        with pytest.raises(socket.error):
+            self.t.connect()
+
+    @patch('socket.socket', return_value=MockSocket())
+    @patch('socket.getaddrinfo',
+           side_effect=[
+               socket.gaierror,
+               [(socket.AF_INET6, 1, socket.IPPROTO_TCP,
+                '', ('::1', 5672))]
+           ])
+    def test_connect_getaddrinfo_raises_gaierror_once_recovers(self, *mocks):
+        self.t.connect()
+
 
 class test_SSLTransport:
 

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -181,14 +181,12 @@ class test_AbstractTransport:
 
     class Transport(transport._AbstractTransport):
 
-        def _connect(self, *args):
-            pass
-
         def _init_socket(self, *args):
             pass
 
     @pytest.fixture(autouse=True)
-    def setup_transport(self):
+    @patch('socket.socket.connect')
+    def setup_transport(self, patching):
         self.t = self.Transport('localhost:5672', 10)
         self.t.connect()
 

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -187,6 +187,7 @@ class test_AbstractTransport:
     @pytest.fixture(autouse=True)
     @patch('socket.socket.connect')
     def setup_transport(self, patching):
+        self.connect_mock = patching
         self.t = self.Transport('localhost:5672', 10)
         self.t.connect()
 
@@ -295,6 +296,13 @@ class test_AbstractTransport:
         with pytest.raises(OSError):
             self.t.write('foo')
         assert not self.t.connected
+
+    def test_connect_socket_fails(self):
+        self.t.sock = Mock()
+        self.t.close()
+        self.connect_mock.side_effect = socket.error
+        with pytest.raises(socket.error):
+            self.t.connect()
 
 
 class test_SSLTransport:


### PR DESCRIPTION
There is no need to send both A and AAAA requests when connecting to a
host since we are interested in a single address only. So if the host
resolves into IPv4 address, we can skip request for AAAA since it will
not be used anyway.

This sounds like a minor optimization, but it comes as a huge win in
case where DNS resolver is not configured for the requested host name,
but the name is listed in /etc/hosts with a IPv4 address. In this case,
resolution is very quick (the file is local, so no DNS request is sent),
except for the fact that we still ask for AAAA record for the host name.
A misconfigured DNS resolver can take time until it will time out the
request (30 seconds is a common length for Linux), which is an
unnecessary delay.

This exact situation hit OpenStack TripleO CI where DNS was not
configured, but resolution is implemented via /etc/hosts file which did
not include IPv6 entries.

OpenStack bug: https://bugs.launchpad.net/neutron/+bug/1696094