### PR TITLE
publishing zero-length messages

### DIFF
--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -159,7 +159,7 @@ def frame_writer(connection, transport,
             pack_into('>BHI%dsB' % framelen, buf, offset,
                       type_, channel, framelen, frame, 0xce)
             offset += 8 + framelen
-            if body:
+            if body is not None:
                 frame = b''.join([
                     pack('>HHQ', method_sig[0], 0, len(body)),
                     properties,
@@ -170,10 +170,12 @@ def frame_writer(connection, transport,
                           2, channel, framelen, frame, 0xce)
                 offset += 8 + framelen
 
-                framelen = len(body)
-                pack_into('>BHI%dsB' % framelen, buf, offset,
-                          3, channel, framelen, str_to_bytes(body), 0xce)
-                offset += 8 + framelen
+                bodylen = len(body)
+                if bodylen > 0:
+                    framelen = bodylen
+                    pack_into('>BHI%dsB' % framelen, buf, offset,
+                              3, channel, framelen, str_to_bytes(body), 0xce)
+                    offset += 8 + framelen
 
             write(view[:offset])
 

--- a/t/unit/test_method_framing.py
+++ b/t/unit/test_method_framing.py
@@ -99,3 +99,9 @@ class test_frame_writer:
         frame = 2, 1, spec.Basic.Publish, b'x' * 10, msg
         self.g(*frame)
         self.write.assert_called()
+
+    def test_write_zero_len_body(self):
+        msg = Message(body=b'', content_type='application/octet-stream')
+        frame = 2, 1, spec.Basic.Publish, b'x' * 10, msg
+        self.g(*frame)
+        self.write.assert_called()


### PR DESCRIPTION
RabbitMQ expects a header frame and no body frame when the body is zero length. This may also be true of other 0.9.x AMQP servers, but I haven't tested those.

fixes #151