### PR TITLE
Convert mechanisms to bytes if it is a string

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,7 +5,7 @@ py-amqp is fork of amqplib used by Kombu containing additional features and impr
 The previous amqplib changelog is here:
 http://code.google.com/p/py-amqplib/source/browse/CHANGES
 
-.. _version-2.2.0
+.. _version-2.2.0:
 
 2.2.0
 =====

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -33,7 +33,7 @@ from .exceptions import (
     ConnectionForced, ConnectionError, error_for_code,
     RecoverableConnectionError, RecoverableChannelError,
 )
-from .five import array, items, monotonic, range, values
+from .five import array, items, monotonic, range, values, string
 from .method_framing import frame_handler, frame_writer
 from .transport import Transport
 
@@ -344,6 +344,8 @@ class Connection(AbstractChannel):
         self.version_major = version_major
         self.version_minor = version_minor
         self.server_properties = server_properties
+        if isinstance(mechanisms, string):
+            mechanisms = mechanisms.encode('utf-8')
         self.mechanisms = mechanisms.split(b' ')
         self.locales = locales.split(' ')
         AMQP_LOGGER.debug(

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -104,6 +104,23 @@ class test_Connection:
             ),
         )
 
+
+    def test_on_start_string_mechanisms(self):
+        self.conn._on_start(3, 4, {'foo': 'bar'}, 'x y z AMQPLAIN PLAIN',
+                            'en_US en_GB')
+        assert self.conn.version_major == 3
+        assert self.conn.version_minor == 4
+        assert self.conn.server_properties == {'foo': 'bar'}
+        assert self.conn.mechanisms == [b'x', b'y', b'z',
+                                        b'AMQPLAIN', b'PLAIN']
+        assert self.conn.locales == ['en_US', 'en_GB']
+        self.conn.send_method.assert_called_with(
+            spec.Connection.StartOk, 'FsSs', (
+                self.conn.client_properties, b'AMQPLAIN',
+                self.conn.authentication[0].start(self.conn), self.conn.locale,
+            ),
+        )
+
     def test_missing_credentials(self):
         with pytest.raises(ValueError):
             self.conn = Connection(userid=None, password=None)

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -104,7 +104,6 @@ class test_Connection:
             ),
         )
 
-
     def test_on_start_string_mechanisms(self):
         self.conn._on_start(3, 4, {'foo': 'bar'}, 'x y z AMQPLAIN PLAIN',
                             'en_US en_GB')


### PR DESCRIPTION
This fixes a problem with 2.2.0 and Celery 4.0.2.

Fixes #155 