### PR TITLE
Update UTF-8 encoding behavior between Py2/Py3

### DIFF
--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -290,14 +290,14 @@ def dumps(format, values):
             val = val or ''
             bitcount = _flushbits(bits, write)
             if isinstance(val, string):
-                val = val.encode('utf-8')
+                val = val.encode('utf-8', 'surrogatepass')
             write(pack('B', len(val)))
             write(val)
         elif p == 'S':
             val = val or ''
             bitcount = _flushbits(bits, write)
             if isinstance(val, string):
-                val = val.encode('utf-8')
+                val = val.encode('utf-8', 'surrogatepass')
             write(pack('>I', len(val)))
             write(val)
         elif p == 'F':
@@ -318,7 +318,7 @@ def _write_table(d, write, bits, pack=pack):
     twrite = out.write
     for k, v in items(d):
         if isinstance(k, string):
-            k = k.encode('utf-8')
+            k = k.encode('utf-8', 'surrogatepass')
         twrite(pack('B', len(k)))
         twrite(k)
         try:
@@ -352,7 +352,7 @@ def _write_item(v, write, bits, pack=pack,
                 None_t=None):
     if isinstance(v, (string_t, bytes)):
         if isinstance(v, string):
-            v = v.encode('utf-8')
+            v = v.encode('utf-8', 'surrogatepass')
         write(pack('>cI', b'S', len(v)))
         write(v)
     elif isinstance(v, bool):


### PR DESCRIPTION
Python 2 defaults to 'surrogatepass' behavior when encoding a string with invalid UTF-8 bytes, in that it will allow surrogates to passthrough. Python 3 throws errors by default. This means systems using Celery with AMQP that deal with passing around potentially bunk content will fail out.

I made a similar change to core ElasticSearch Python libraries to solve similar issues there.

Resolves https://github.com/celery/py-amqp/issues/165