### PR TITLE
#145: Cleanup TCP configurations across platforms and unified defaults into one dict

### DIFF
--- a/t/unit/test_platform.py
+++ b/t/unit/test_platform.py
@@ -1,6 +1,19 @@
 from __future__ import absolute_import, unicode_literals
+
+import itertools
+import operator
+
 import pytest
+
 from amqp.platform import _linux_version_to_tuple
+
+
+def reload_module(module):
+    try:
+        import importlib
+        importlib.reload(module)
+    except Exception:
+        reload(module)
 
 
 def test_struct_argument_type():
@@ -14,6 +27,41 @@ def test_struct_argument_type():
     ('4.4.34+', (4, 4, 34)),
     ('4.4.what', (4, 4, 0)),
     ('4.what.what', (4, 0, 0)),
+    ('4.4.0-43-Microsoft', (4, 4, 0)),
 ])
 def test_linux_version_to_tuple(s, expected):
     assert _linux_version_to_tuple(s) == expected
+
+
+def monkeypatch_platform(monkeypatch, sys_platform, platform_release):
+    monkeypatch.setattr("sys.platform", sys_platform)
+
+    def release():
+        return platform_release
+
+    monkeypatch.setattr("platform.release", release)
+
+
+def test_tcp_opts_change(monkeypatch):
+    monkeypatch_platform(monkeypatch, 'linux', '2.6.36-1-amd64')
+
+    import amqp.platform
+    reload_module(amqp.platform)
+    old_linux = amqp.platform.KNOWN_TCP_OPTS
+
+    monkeypatch_platform(monkeypatch, 'linux', '2.6.37-0-41-generic')
+    reload_module(amqp.platform)
+    new_linux = amqp.platform.KNOWN_TCP_OPTS
+
+    monkeypatch_platform(monkeypatch, 'win32', '7')
+    reload_module(amqp.platform)
+    win = amqp.platform.KNOWN_TCP_OPTS
+
+    monkeypatch_platform(monkeypatch, 'linux', '4.4.0-43-Microsoft')
+    reload_module(amqp.platform)
+    win_bash = amqp.platform.KNOWN_TCP_OPTS
+
+    li = [old_linux, new_linux, win, win_bash]
+    assert all(operator.ne(*i) for i in itertools.combinations(li, 2))
+
+    assert len(win) <= len(win_bash) < len(old_linux) < len(new_linux)

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -9,6 +9,7 @@ from case import Mock, patch
 from amqp import transport
 from amqp.exceptions import UnexpectedFrame
 from amqp.platform import pack
+from amqp.transport import _AbstractTransport
 
 
 class MockSocket(object):
@@ -175,6 +176,12 @@ class test_socket_options:
         expected = 0
         result = self.socket.getsockopt(socket.SOL_TCP, socket.TCP_NODELAY)
         assert result == expected
+
+    def test_platform_socket_opts(self):
+        s = socket.socket()
+        opts = _AbstractTransport(self.host)._get_tcp_socket_defaults(s)
+
+        assert opts
 
 
 class test_AbstractTransport:


### PR DESCRIPTION
This commit is meant to fix #145 , but also goes further to refactor the default TCP settings which were scattered in different places throughout the code.  Now, TCP settings are clearly defined within platform.py, and the correct TCP settings are declared here by moving the KNOWN_TCP_OPTS.  There are no longer HAS_TCP_* settings which led to fairly confusing code.

#145 was caused by WSL not supporting the majority of TCP platforms, but Python's socket library making them available because it thinks it's a standard Linux platform.