### PR TITLE
Python 3 UTF-8 Encode/Decode w/ Surrogates

### DIFF
--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -194,13 +194,13 @@ def loads(format, buf, offset=0,
             bitcount = bits = 0
             slen, = unpack_from('B', buf, offset)
             offset += 1
-            val = buf[offset:offset + slen].decode('utf-8')
+            val = buf[offset:offset + slen].decode('utf-8', 'surrogatepass')
             offset += slen
         elif p == 'S':
             bitcount = bits = 0
             slen, = unpack_from('>I', buf, offset)
             offset += 4
-            val = buf[offset:offset + slen].decode('utf-8')
+            val = buf[offset:offset + slen].decode('utf-8', 'surrogatepass')
             offset += slen
         elif p == 'F':
             bitcount = bits = 0

--- a/amqp/utils.py
+++ b/amqp/utils.py
@@ -86,7 +86,7 @@ else:
     def str_to_bytes(s):                # noqa
         """Convert str to bytes."""
         if isinstance(s, unicode):
-            return s.encode()
+            return s.encode('utf-8')
         return s
 
     def bytes_to_str(s):                # noqa

--- a/amqp/utils.py
+++ b/amqp/utils.py
@@ -73,13 +73,13 @@ if is_py3k:  # pragma: no cover
     def str_to_bytes(s):
         """Convert str to bytes."""
         if isinstance(s, str):
-            return s.encode()
+            return s.encode('utf-8', 'surrogatepass')
         return s
 
     def bytes_to_str(s):
         """Convert bytes to str."""
         if isinstance(s, bytes):
-            return s.decode()
+            return s.decode('utf-8', 'surrogatepass')
         return s
 else:
 

--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -2,7 +2,7 @@ setuptools>=20.6.7
 wheel>=0.29.0
 flake8>=2.5.4
 flakeplus>=1.1
-tox>=2.3.1
+tox>=2.9.1
 sphinx2rst>=1.0
 bumpversion
 pydocstyle==1.1.1

--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -2,7 +2,7 @@ setuptools>=20.6.7
 wheel>=0.29.0
 flake8>=2.5.4
 flakeplus>=1.1
-tox>=2.9.1
+tox>=2.3.1
 sphinx2rst>=1.0
 bumpversion
 pydocstyle==1.1.1

--- a/t/unit/test_utils.py
+++ b/t/unit/test_utils.py
@@ -60,7 +60,7 @@ class test_bytes_to_str:
         assert bytes_to_str(b'foo')
 
     def test_support_surrogates(self):
-        assert bytes_to_str('\ud83d\ude4f'.encode('utf-8', 'surrogatepass')) == '\ud83d\ude4f'
+        assert bytes_to_str(u'\ud83d\ude4f') == u'\ud83d\ude4f'
 
 
 class test_NullHandler:

--- a/t/unit/test_utils.py
+++ b/t/unit/test_utils.py
@@ -47,6 +47,9 @@ class test_str_to_bytes:
     def test_from_bytes(self):
         assert isinstance(str_to_bytes(b'foo'), bytes)
 
+    def test_supports_surrogates(self):
+        assert str_to_bytes('\ud83d\ude4f') == '\ud83d\ude4f'.encode('utf-8', 'surrogatepass')
+
 
 class test_bytes_to_str:
 
@@ -55,6 +58,9 @@ class test_bytes_to_str:
 
     def test_from_bytes(self):
         assert bytes_to_str(b'foo')
+
+    def test_support_surrogates(self):
+        assert bytes_to_str('\ud83d\ude4f'.encode('utf-8', 'surrogatepass')) == '\ud83d\ude4f'
 
 
 class test_NullHandler:

--- a/t/unit/test_utils.py
+++ b/t/unit/test_utils.py
@@ -48,7 +48,8 @@ class test_str_to_bytes:
         assert isinstance(str_to_bytes(b'foo'), bytes)
 
     def test_supports_surrogates(self):
-        assert str_to_bytes('\ud83d\ude4f') == '\ud83d\ude4f'.encode('utf-8', 'surrogatepass')
+        bytes_with_surrogates = '\ud83d\ude4f'.encode('utf-8', 'surrogatepass')
+        assert str_to_bytes('\ud83d\ude4f') == bytes_with_surrogates
 
 
 class test_bytes_to_str:


### PR DESCRIPTION
Ensures that all call sites for decoding bytes to str allow surrogates, which the encoding mechanism now supports.

See:  https://github.com/celery/py-amqp/pull/164