### PR TITLE
Fix ResourceWarning in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import io
 import os
 import re
 import sys
-import codecs
 
 import setuptools
 import setuptools.command.test
@@ -71,8 +71,8 @@ def strip_comments(l):
 
 
 def reqs(f):
-    req = filter(None, [strip_comments(l) for l in open(
-        os.path.join(os.getcwd(), 'requirements', f)).readlines()])
+    with open(os.path.join(os.getcwd(), 'requirements', f)) as fp:
+        req = filter(None, [strip_comments(l) for l in fp.readlines()])
     # filter returns filter object(iterator) in Python 3,
     # but a list in Python 2.7, so make sure it returns a list.
     return list(req)
@@ -81,7 +81,8 @@ def reqs(f):
 # -*- Long Description -*-
 
 if os.path.exists('README.rst'):
-    long_description = codecs.open('README.rst', 'r', 'utf-8').read()
+    with io.open('README.rst', encoding='utf-8') as fp:
+        long_description = fp.read()
 else:
     long_description = 'See http://pypi.python.org/pypi/amqp'
 


### PR DESCRIPTION
When Python is executed with warnings enabled (e.g. `python3 -Wall setup.py ...`), `ResourceWarning`s appear on stderr. This occurs because files are not explicitly closed. Always use a context manager to close files when finished.