### PR TITLE
Fix for TypeError when setting socket options

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -196,8 +196,8 @@ class _AbstractTransport(object):
             if enum:
                 if opt in DEFAULT_SOCKET_SETTINGS:
                     tcp_opts[enum] = DEFAULT_SOCKET_SETTINGS[opt]
-                else:
-                    tcp_opts[enum] = sock.getsockopt(SOL_TCP, opt)
+                elif hasattr(socket, opt):
+                    tcp_opts[enum] = sock.getsockopt(SOL_TCP, getattr(socket, opt))
         return tcp_opts
 
     def _set_socket_options(self, socket_settings):


### PR DESCRIPTION
Trying out the current master, I got the following stacktrace:
 ```
File "/Users/matthias/Dev/Python/Git/py-amqp/amqp/connection.py", line 280, in connect
  self.transport.connect()
File "/Users/matthias/Dev/Python/Git/py-amqp/amqp/transport.py", line 81, in connect
  self.socket_settings, self.read_timeout, self.write_timeout,
File "/Users/matthias/Dev/Python/Git/py-amqp/amqp/transport.py", line 165, in _init_socket
  self._set_socket_options(socket_settings)
File "/Users/matthias/Dev/Python/Git/py-amqp/amqp/transport.py", line 204, in _set_socket_options
  tcp_opts = self._get_tcp_socket_defaults(self.sock)
File "/Users/matthias/Dev/Python/Git/py-amqp/amqp/transport.py", line 200, in _get_tcp_socket_defaults
  tcp_opts[enum] = sock.getsockopt(SOL_TCP, opt)
File "/usr/local/Cellar/python/2.7.14/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 228, in meth
  return getattr(self._sock,name)(*args)
TypeError: an integer is required
```

It seems this got introduced with #167, and although it is covered by tests, the Mock connection does not show the same behavior. This PR looks up the required constant on the ``socket`` module (as mentioned in the `socket.getsockopt` Python docs and *getsockopt(2)* man page). For now it silently ignores unavailable options.