### PR TITLE
Support for EXTERNAL authentication and specific login_method

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -190,6 +190,7 @@ class Connection(AbstractChannel):
             self.authentication = (sasl.RAW(login_method, login_response),)
         elif userid is not None and password is not None:
             self.authentication = (sasl.GSSAPI(userid, fail_soft=True),
+                                   sasl.EXTERNAL(),
                                    sasl.AMQPLAIN(userid, password),
                                    sasl.PLAIN(userid, password))
         else:

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -87,7 +87,7 @@ class Connection(AbstractChannel):
     'GSSAPI', 'EXTERNAL', 'AMQPLAIN', or 'PLAIN'.
     Otherwise authentication will be performed using any supported method
     preferred by the server. Userid and passwords apply to AMQPLAIN and
-    PLAIN authentication, whereas on GSSAPI only userid will be used as
+    PLAIN authentication, whereas on GSSAPI only userid will be used as the
     client name. For EXTERNAL authentication both userid and password are
     ignored.
 

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -199,11 +199,13 @@ class Connection(AbstractChannel):
                 auth = sasl.EXTERNAL()
             elif login_method == 'AMQPLAIN':
                 if userid is None or password is None:
-                    raise ValueError("Must supply authentication or userid/password")
+                    raise ValueError(
+                        "Must supply authentication or userid/password")
                 auth = sasl.AMQPLAIN(userid, password)
             elif login_method == 'PLAIN':
                 if userid is None or password is None:
-                    raise ValueError("Must supply authentication or userid/password")
+                    raise ValueError(
+                        "Must supply authentication or userid/password")
                 auth = sasl.PLAIN(userid, password)
             elif login_response is not None:
                 auth = sasl.RAW(login_method, login_response)

--- a/amqp/sasl.py
+++ b/amqp/sasl.py
@@ -137,6 +137,19 @@ def _get_gssapi_mechanism():
 GSSAPI = _get_gssapi_mechanism()
 
 
+class EXTERNAL(SASL):
+    """EXTERNAL SASL mechanism.
+
+    Enables external authentication, i.e. not handled through this protocol.
+    Only passes 'EXTERNAL' as authentication mechanism, but no further
+    authentication data.
+    """
+    mechanism = b'EXTERNAL'
+
+    def start(self, connection):
+        return b''
+
+
 class RAW(SASL):
     """A generic custom SASL mechanism.
 

--- a/amqp/sasl.py
+++ b/amqp/sasl.py
@@ -36,6 +36,8 @@ class PLAIN(SASL):
         self.username, self.password = username, password
 
     def start(self, connection):
+        if self.username is None or self.password is None:
+            return NotImplemented
         login_response = BytesIO()
         login_response.write(b'\0')
         login_response.write(self.username.encode('utf-8'))
@@ -56,6 +58,8 @@ class AMQPLAIN(SASL):
         self.username, self.password = username, password
 
     def start(self, connection):
+        if self.username is None or self.password is None:
+            return NotImplemented
         login_response = BytesIO()
         _write_table({b'LOGIN': self.username, b'PASSWORD': self.password},
                      login_response.write, [])

--- a/amqp/sasl.py
+++ b/amqp/sasl.py
@@ -148,6 +148,7 @@ class EXTERNAL(SASL):
     Only passes 'EXTERNAL' as authentication mechanism, but no further
     authentication data.
     """
+
     mechanism = b'EXTERNAL'
 
     def start(self, connection):

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -59,6 +59,12 @@ class test_Connection:
         assert auth.username == 'foo'
         assert auth.password == 'bar'
 
+    def test_login_method(self):
+        self.conn = Connection(login_method='AMQPLAIN')
+        auths = self.conn.authentication
+        assert len(auths) == 1
+        assert isinstance(auths[0], AMQPLAIN)
+
     def test_enter_exit(self):
         self.conn.connect = Mock(name='connect')
         self.conn.close = Mock(name='close')

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -133,7 +133,8 @@ class test_Connection:
 
     def test_missing_credentials(self):
         with pytest.raises(ValueError):
-            self.conn = Connection(userid=None, password=None, login_method='AMPQPLAIN')
+            self.conn = Connection(userid=None, password=None,
+                                   login_method='AMPQPLAIN')
         with pytest.raises(ValueError):
             self.conn = Connection(password=None, login_method='PLAIN')
 

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -133,9 +133,9 @@ class test_Connection:
 
     def test_missing_credentials(self):
         with pytest.raises(ValueError):
-            self.conn = Connection(userid=None, password=None)
+            self.conn = Connection(userid=None, password=None, login_method='AMPQPLAIN')
         with pytest.raises(ValueError):
-            self.conn = Connection(password=None)
+            self.conn = Connection(password=None, login_method='PLAIN')
 
     def test_mechanism_mismatch(self):
         with pytest.raises(ConnectionError):

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -65,7 +65,8 @@ class test_Connection:
 
     def test_login_method_gssapi(self):
         try:
-            self.conn = Connection(userid=None, password=None, login_method='GSSAPI')
+            self.conn = Connection(userid=None, password=None,
+                                   login_method='GSSAPI')
         except NotImplementedError:
             pass
         else:
@@ -74,7 +75,8 @@ class test_Connection:
             assert isinstance(auths[0], GSSAPI)
 
     def test_login_method_external(self):
-        self.conn = Connection(userid=None, password=None, login_method='EXTERNAL')
+        self.conn = Connection(userid=None, password=None,
+                               login_method='EXTERNAL')
         auths = self.conn.authentication
         assert len(auths) == 1
         assert isinstance(auths[0], EXTERNAL)

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -162,9 +162,13 @@ class test_Connection:
     def test_missing_credentials(self):
         with pytest.raises(ValueError):
             self.conn = Connection(userid=None, password=None,
-                                   login_method='AMPQPLAIN')
+                                   login_method='AMQPLAIN')
         with pytest.raises(ValueError):
             self.conn = Connection(password=None, login_method='PLAIN')
+
+    def test_invalid_method(self):
+        with pytest.raises(ValueError):
+            self.conn = Connection(login_method='any')
 
     def test_mechanism_mismatch(self):
         with pytest.raises(ConnectionError):

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -10,7 +10,7 @@ from amqp import Connection, spec
 from amqp.connection import SSLError
 from amqp.exceptions import ConnectionError, NotFound, ResourceError
 from amqp.five import items
-from amqp.sasl import AMQPLAIN, PLAIN, SASL
+from amqp.sasl import AMQPLAIN, PLAIN, SASL, EXTERNAL
 from amqp.transport import TCPTransport
 
 
@@ -41,17 +41,23 @@ class test_Connection:
         self.conn = Connection(authentication=(authentication,))
         assert self.conn.authentication == (authentication,)
 
+    def test_external(self):
+        self.conn = Connection()
+        assert isinstance(self.conn.authentication[1], EXTERNAL)
+
     def test_amqplain(self):
         self.conn = Connection(userid='foo', password='bar')
-        assert isinstance(self.conn.authentication[1], AMQPLAIN)
-        assert self.conn.authentication[1].username == 'foo'
-        assert self.conn.authentication[1].password == 'bar'
+        auth = self.conn.authentication[2]
+        assert isinstance(auth, AMQPLAIN)
+        assert auth.username == 'foo'
+        assert auth.password == 'bar'
 
     def test_plain(self):
         self.conn = Connection(userid='foo', password='bar')
-        assert isinstance(self.conn.authentication[2], PLAIN)
-        assert self.conn.authentication[2].username == 'foo'
-        assert self.conn.authentication[2].password == 'bar'
+        auth = self.conn.authentication[3]
+        assert isinstance(auth, PLAIN)
+        assert auth.username == 'foo'
+        assert auth.password == 'bar'
 
     def test_enter_exit(self):
         self.conn.connect = Mock(name='connect')

--- a/t/unit/test_sasl.py
+++ b/t/unit/test_sasl.py
@@ -28,6 +28,12 @@ class test_SASL:
         assert response.split(b'\0') == \
             [b'', username.encode('utf-8'), password.encode('utf-8')]
 
+    def test_plain_no_password(self):
+        username, password = 'foo', None
+        mech = sasl.PLAIN(username, password)
+        response = mech.start(None)
+        assert response == NotImplemented
+
     def test_amqplain(self):
         username, password = 'foo', 'bar'
         mech = sasl.AMQPLAIN(username, password)
@@ -38,6 +44,12 @@ class test_SASL:
                      login_response.write, [])
         expected_response = login_response.getvalue()[4:]
         assert response == expected_response
+
+    def test_amqplain_no_password(self):
+        username, password = 'foo', None
+        mech = sasl.AMQPLAIN(username, password)
+        response = mech.start(None)
+        assert response == NotImplemented
 
     def test_gssapi_missing(self):
         gssapi = sys.modules.pop('gssapi', None)
@@ -147,3 +159,9 @@ class test_SASL:
                                                       creds=credentials)
             context.step.assert_called_with(None)
             assert response == b'secrets'
+
+    def test_external(self):
+        mech = sasl.EXTERNAL()
+        response = mech.start(None)
+        assert isinstance(response, bytes)
+        assert response == b''


### PR DESCRIPTION
This PR addresses two issues that can occur when using the library as part of Celery 4.x in combination with RabbitMQ:

1. The EXTERNAL authentication is not supported. This could also be added by implementing it in our application and passing it through the `authentication` parameter; but since it is mentioned in the [Kombu docs](http://docs.celeryproject.org/projects/kombu/en/latest/reference/kombu.connection.html), I think it should also be implemented directly in `py-amqp`.

2. Setting the `login_method` parameter, as suggested in the [Celery configuration docs](http://docs.celeryproject.org/en/latest/userguide/configuration.html#broker-login-method) or the [Kombu docs](http://docs.celeryproject.org/projects/kombu/en/latest/reference/kombu.connection.html) does not work as expected. It is not possible to e.g. force using `GSSAPI` instead of `AMQPLAIN` and fail if the server does not support it. The only way to do this is using the `authentication` parameter, passing in the `sasl` object.

These commits add an `EXTERNAL` authentication class to the `sasl` module, and to the list of mechanisms supported where demanded by the server. In addition, the  `login_method` parameter forces a specific method, also considering that `EXTERNAL` and `GSSAPI` do not require `userid` or `password` to be set.