### PR TITLE
Run flake8 on both Python 2.7 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
       env: TOXENV=3.6
     - python: 2.7
       env: TOXENV=flake8
+    - python: 3.6
+      env: TOXENV=flake8
     - python: 2.7
       env: TOXENV=flakeplus
     - python: 2.7


### PR DESCRIPTION
Flake8 will produce different results on Python 2 and 3 so let's make sure that the tests pass on both.

See the first NOTE at: http://flake8.pycqa.org