### PR TITLE
Testing: Replace @patch decorators

### DIFF
--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -242,7 +242,7 @@ def _flushbits(bits, write, pack=pack):
 
 
 def dumps(format, values):
-    """"Serialize AMQP arguments.
+    """Serialize AMQP arguments.
 
     Notes:
         bit = b

--- a/amqp/utils.py
+++ b/amqp/utils.py
@@ -85,7 +85,7 @@ else:
 
     def str_to_bytes(s):                # noqa
         """Convert str to bytes."""
-        if isinstance(s, unicode):
+        if isinstance(s, string_t):
             return s.encode('utf-8')
         return s
 

--- a/t/unit/test_channel.py
+++ b/t/unit/test_channel.py
@@ -138,13 +138,13 @@ class test_Channel:
             wait=spec.Exchange.DeclareOk,
         )
 
-    @patch('amqp.channel.warn')
-    def test_exchange_declare__auto_delete(self, warn):
-        self.c.exchange_declare(
-            'foo', 'direct', False, True,
-            auto_delete=True, nowait=False, arguments={'x': 1},
-        )
-        warn.assert_called()
+    def test_exchange_declare__auto_delete(self):
+        with patch('amqp.channel.warn') as warn:
+            self.c.exchange_declare(
+                'foo', 'direct', False, True,
+                auto_delete=True, nowait=False, arguments={'x': 1},
+            )
+            warn.assert_called()
 
     def test_exchange_delete(self):
         self.c.exchange_delete('foo')
@@ -366,14 +366,14 @@ class test_Channel:
         with pytest.raises(NotFound):
             self.c._on_basic_return(404, 'text', 'ex', 'rkey', 'msg')
 
-    @patch('amqp.channel.error_for_code')
-    def test_on_basic_return__handled(self, error_for_code):
-        callback = Mock(name='callback')
-        self.c.events['basic_return'].add(callback)
-        self.c._on_basic_return(404, 'text', 'ex', 'rkey', 'msg')
-        callback.assert_called_with(
-            error_for_code(), 'ex', 'rkey', 'msg',
-        )
+    def test_on_basic_return__handled(self):
+        with patch('amqp.channel.error_for_code') as error_for_code:
+            callback = Mock(name='callback')
+            self.c.events['basic_return'].add(callback)
+            self.c._on_basic_return(404, 'text', 'ex', 'rkey', 'msg')
+            callback.assert_called_with(
+                error_for_code(), 'ex', 'rkey', 'msg',
+            )
 
     def test_tx_commit(self):
         self.c.tx_commit()

--- a/t/unit/test_platform.py
+++ b/t/unit/test_platform.py
@@ -13,7 +13,7 @@ def reload_module(module):
         import importlib
         importlib.reload(module)
     except Exception:
-        reload(module)
+        reload(module) # noqa -- does not exist on Python3
 
 
 def test_struct_argument_type():

--- a/t/unit/test_sasl.py
+++ b/t/unit/test_sasl.py
@@ -88,9 +88,8 @@ class test_SASL:
             else:
                 sys.modules['gssapi.raw.misc'] = orig_gssapi_raw_misc
 
-    @patch('socket.gethostbyaddr')
-    def test_gssapi_rdns(self, gethostbyaddr):
-        with self.fake_gssapi() as gssapi:
+    def test_gssapi_rdns(self):
+        with self.fake_gssapi() as gssapi, patch('socket.gethostbyaddr') as gethostbyaddr:
             connection = Mock()
             connection.transport.sock.getpeername.return_value = ('192.0.2.0',
                                                                   5672)

--- a/t/unit/test_sasl.py
+++ b/t/unit/test_sasl.py
@@ -89,7 +89,8 @@ class test_SASL:
                 sys.modules['gssapi.raw.misc'] = orig_gssapi_raw_misc
 
     def test_gssapi_rdns(self):
-        with self.fake_gssapi() as gssapi, patch('socket.gethostbyaddr') as gethostbyaddr:
+        with self.fake_gssapi() as gssapi, \
+                patch('socket.gethostbyaddr') as gethostbyaddr:
             connection = Mock()
             connection.transport.sock.getpeername.return_value = ('192.0.2.0',
                                                                   5672)

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -212,9 +212,7 @@ class test_AbstractTransport:
 
     @pytest.fixture(autouse=True)
     @patch('socket.socket.connect')
-    def setup_transport(self, *a,**k):
-        if len(a)+len(k) != 1:
-            import pdb;pdb.set_trace()
+    def setup_transport(self, *a, **k):
         self.connect_mock = a[0] if a else k['patching']
         self.t = self.Transport('localhost:5672', 10)
         self.t.connect()
@@ -335,55 +333,55 @@ class test_AbstractTransport:
     def test_connect_socket_initialization_fails(self):
         with patch('socket.socket', side_effect=socket.error), \
             patch('socket.getaddrinfo',
-                return_value=[
-                    (socket.AF_INET, 1, socket.IPPROTO_TCP,
-                        '', ('127.0.0.1', 5672)),
-                    (socket.AF_INET, 1, socket.IPPROTO_TCP,
-                        '', ('127.0.0.2', 5672))
-                ]) as getaddrinfo:
+                  return_value=[
+                      (socket.AF_INET, 1, socket.IPPROTO_TCP,
+                          '', ('127.0.0.1', 5672)),
+                      (socket.AF_INET, 1, socket.IPPROTO_TCP,
+                          '', ('127.0.0.2', 5672))
+                  ]):
             with pytest.raises(socket.error):
                 self.t.connect()
 
     def test_connect_multiple_addr_entries_fails(self):
         with patch('socket.socket', return_value=MockSocket()) as sock_mock, \
             patch('socket.getaddrinfo',
-                return_value=[
-                    (socket.AF_INET, 1, socket.IPPROTO_TCP,
-                        '', ('127.0.0.1', 5672)),
-                    (socket.AF_INET, 1, socket.IPPROTO_TCP,
-                        '', ('127.0.0.2', 5672))
-                ]) as getaddrinfo:
+                  return_value=[
+                      (socket.AF_INET, 1, socket.IPPROTO_TCP,
+                          '', ('127.0.0.1', 5672)),
+                      (socket.AF_INET, 1, socket.IPPROTO_TCP,
+                          '', ('127.0.0.2', 5672))
+                  ]):
             self.t.sock = Mock()
             self.t.close()
             with patch.object(sock_mock.return_value, 'connect',
-                            side_effect=socket.error):
+                              side_effect=socket.error):
                 with pytest.raises(socket.error):
                     self.t.connect()
 
     def test_connect_multiple_addr_entries_succeed(self):
         with patch('socket.socket', return_value=MockSocket()) as sock_mock, \
             patch('socket.getaddrinfo',
-                return_value=[
-                    (socket.AF_INET, 1, socket.IPPROTO_TCP,
-                        '', ('127.0.0.1', 5672)),
-                    (socket.AF_INET, 1, socket.IPPROTO_TCP,
-                        '', ('127.0.0.2', 5672))
-                ]) as getaddrinfo:
+                  return_value=[
+                      (socket.AF_INET, 1, socket.IPPROTO_TCP,
+                          '', ('127.0.0.1', 5672)),
+                      (socket.AF_INET, 1, socket.IPPROTO_TCP,
+                          '', ('127.0.0.2', 5672))
+                  ]):
             self.t.sock = Mock()
             self.t.close()
             with patch.object(sock_mock.return_value, 'connect',
-                            side_effect=(socket.error, None)):
+                              side_effect=(socket.error, None)):
                 self.t.connect()
 
     def test_connect_short_curcuit_on_INET_succeed(self):
         with patch('socket.socket', return_value=MockSocket()), \
             patch('socket.getaddrinfo',
-                side_effect=[
-                    [(socket.AF_INET, 1, socket.IPPROTO_TCP,
-                        '', ('127.0.0.1', 5672))],
-                    [(socket.AF_INET6, 1, socket.IPPROTO_TCP,
-                        '', ('::1', 5672))]
-                ]) as getaddrinfo:
+                  side_effect=[
+                      [(socket.AF_INET, 1, socket.IPPROTO_TCP,
+                          '', ('127.0.0.1', 5672))],
+                      [(socket.AF_INET6, 1, socket.IPPROTO_TCP,
+                          '', ('::1', 5672))]
+                  ]) as getaddrinfo:
             self.t.sock = Mock()
             self.t.close()
             self.t.connect()
@@ -393,43 +391,43 @@ class test_AbstractTransport:
     def test_connect_short_curcuit_on_INET_fails(self):
         with patch('socket.socket', return_value=MockSocket()) as sock_mock, \
             patch('socket.getaddrinfo',
-                side_effect=[
-                    [(socket.AF_INET, 1, socket.IPPROTO_TCP,
-                        '', ('127.0.0.1', 5672))],
-                    [(socket.AF_INET6, 1, socket.IPPROTO_TCP,
-                        '', ('::1', 5672))]
-                ]) as getaddrinfo:
+                  side_effect=[
+                      [(socket.AF_INET, 1, socket.IPPROTO_TCP,
+                          '', ('127.0.0.1', 5672))],
+                      [(socket.AF_INET6, 1, socket.IPPROTO_TCP,
+                          '', ('::1', 5672))]
+                  ]) as getaddrinfo:
             self.t.sock = Mock()
             self.t.close()
             with patch.object(sock_mock.return_value, 'connect',
-                            side_effect=(socket.error, None)):
+                              side_effect=(socket.error, None)):
                 self.t.connect()
             getaddrinfo.assert_has_calls(
                 [call('localhost', 5672, addr_type, ANY, ANY)
-                for addr_type in (socket.AF_INET, socket.AF_INET6)])
+                 for addr_type in (socket.AF_INET, socket.AF_INET6)])
 
     def test_connect_getaddrinfo_raises_gaierror(self):
-        with patch('socket.getaddrinfo', side_effect=socket.gaierror) as getaddrinfo:
+        with patch('socket.getaddrinfo', side_effect=socket.gaierror):
             with pytest.raises(socket.error):
                 self.t.connect()
 
     def test_connect_getaddrinfo_raises_gaierror_once_recovers(self):
         with patch('socket.socket', return_value=MockSocket()), \
             patch('socket.getaddrinfo',
-                side_effect=[
-                    socket.gaierror,
-                    [(socket.AF_INET6, 1, socket.IPPROTO_TCP,
-                        '', ('::1', 5672))]
-                ]):
+                  side_effect=[
+                      socket.gaierror,
+                      [(socket.AF_INET6, 1, socket.IPPROTO_TCP,
+                          '', ('::1', 5672))]
+                  ]):
             self.t.connect()
 
     def test_connect_survives_not_implemented_set_cloexec(self):
         with patch('socket.socket', return_value=MockSocket()), \
             patch('socket.getaddrinfo',
-                return_value=[(socket.AF_INET, 1, socket.IPPROTO_TCP,
-                                '', ('127.0.0.1', 5672))]):
+                  return_value=[(socket.AF_INET, 1, socket.IPPROTO_TCP,
+                                 '', ('127.0.0.1', 5672))]):
             with patch('amqp.transport.set_cloexec',
-                    side_effect=NotImplementedError) as cloexec_mock:
+                       side_effect=NotImplementedError) as cloexec_mock:
                 self.t.connect()
             assert cloexec_mock.called
 
@@ -473,7 +471,8 @@ class test_SSLTransport:
         self.t._wrap_context.assert_called_with(sock, {'foo': 1}, c=2)
 
     def test_wrap_context(self):
-        with patch('ssl.create_default_context', create=True) as create_default_context:
+        with patch('ssl.create_default_context', create=True) \
+                as create_default_context:
             sock = Mock()
             self.t._wrap_context(sock, {'f': 1}, check_hostname=True, bar=3)
             create_default_context.assert_called_with(bar=3)

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -212,8 +212,10 @@ class test_AbstractTransport:
 
     @pytest.fixture(autouse=True)
     @patch('socket.socket.connect')
-    def setup_transport(self, patching):
-        self.connect_mock = patching
+    def setup_transport(self, *a,**k):
+        if len(a)+len(k) != 1:
+            import pdb;pdb.set_trace()
+        self.connect_mock = a[0] if a else k['patching']
         self.t = self.Transport('localhost:5672', 10)
         self.t.connect()
 
@@ -330,108 +332,106 @@ class test_AbstractTransport:
         with pytest.raises(socket.error):
             self.t.connect()
 
-    @patch('socket.socket', side_effect=socket.error)
-    @patch('socket.getaddrinfo',
-           return_value=[
-               (socket.AF_INET, 1, socket.IPPROTO_TCP,
-                '', ('127.0.0.1', 5672)),
-               (socket.AF_INET, 1, socket.IPPROTO_TCP,
-                '', ('127.0.0.2', 5672))
-           ])
-    def test_connect_socket_initialization_fails(self, getaddrinfo, sock_mock):
-        with pytest.raises(socket.error):
-            self.t.connect()
-
-    @patch('socket.socket', return_value=MockSocket())
-    @patch('socket.getaddrinfo',
-           return_value=[
-               (socket.AF_INET, 1, socket.IPPROTO_TCP,
-                '', ('127.0.0.1', 5672)),
-               (socket.AF_INET, 1, socket.IPPROTO_TCP,
-                '', ('127.0.0.2', 5672))
-           ])
-    def test_connect_multiple_addr_entries_fails(self, getaddrinfo, sock_mock):
-        self.t.sock = Mock()
-        self.t.close()
-        with patch.object(sock_mock.return_value, 'connect',
-                          side_effect=socket.error):
+    def test_connect_socket_initialization_fails(self):
+        with patch('socket.socket', side_effect=socket.error), \
+            patch('socket.getaddrinfo',
+                return_value=[
+                    (socket.AF_INET, 1, socket.IPPROTO_TCP,
+                        '', ('127.0.0.1', 5672)),
+                    (socket.AF_INET, 1, socket.IPPROTO_TCP,
+                        '', ('127.0.0.2', 5672))
+                ]) as getaddrinfo:
             with pytest.raises(socket.error):
                 self.t.connect()
 
-    @patch('socket.socket', return_value=MockSocket())
-    @patch('socket.getaddrinfo',
-           return_value=[
-               (socket.AF_INET, 1, socket.IPPROTO_TCP,
-                '', ('127.0.0.1', 5672)),
-               (socket.AF_INET, 1, socket.IPPROTO_TCP,
-                '', ('127.0.0.2', 5672))
-           ])
-    def test_connect_multiple_addr_entries_succeed(self, getaddrinfo,
-                                                   sock_mock):
-        self.t.sock = Mock()
-        self.t.close()
-        with patch.object(sock_mock.return_value, 'connect',
-                          side_effect=(socket.error, None)):
+    def test_connect_multiple_addr_entries_fails(self):
+        with patch('socket.socket', return_value=MockSocket()) as sock_mock, \
+            patch('socket.getaddrinfo',
+                return_value=[
+                    (socket.AF_INET, 1, socket.IPPROTO_TCP,
+                        '', ('127.0.0.1', 5672)),
+                    (socket.AF_INET, 1, socket.IPPROTO_TCP,
+                        '', ('127.0.0.2', 5672))
+                ]) as getaddrinfo:
+            self.t.sock = Mock()
+            self.t.close()
+            with patch.object(sock_mock.return_value, 'connect',
+                            side_effect=socket.error):
+                with pytest.raises(socket.error):
+                    self.t.connect()
+
+    def test_connect_multiple_addr_entries_succeed(self):
+        with patch('socket.socket', return_value=MockSocket()) as sock_mock, \
+            patch('socket.getaddrinfo',
+                return_value=[
+                    (socket.AF_INET, 1, socket.IPPROTO_TCP,
+                        '', ('127.0.0.1', 5672)),
+                    (socket.AF_INET, 1, socket.IPPROTO_TCP,
+                        '', ('127.0.0.2', 5672))
+                ]) as getaddrinfo:
+            self.t.sock = Mock()
+            self.t.close()
+            with patch.object(sock_mock.return_value, 'connect',
+                            side_effect=(socket.error, None)):
+                self.t.connect()
+
+    def test_connect_short_curcuit_on_INET_succeed(self):
+        with patch('socket.socket', return_value=MockSocket()), \
+            patch('socket.getaddrinfo',
+                side_effect=[
+                    [(socket.AF_INET, 1, socket.IPPROTO_TCP,
+                        '', ('127.0.0.1', 5672))],
+                    [(socket.AF_INET6, 1, socket.IPPROTO_TCP,
+                        '', ('::1', 5672))]
+                ]) as getaddrinfo:
+            self.t.sock = Mock()
+            self.t.close()
+            self.t.connect()
+            getaddrinfo.assert_called_with(
+                'localhost', 5672, socket.AF_INET, ANY, ANY)
+
+    def test_connect_short_curcuit_on_INET_fails(self):
+        with patch('socket.socket', return_value=MockSocket()) as sock_mock, \
+            patch('socket.getaddrinfo',
+                side_effect=[
+                    [(socket.AF_INET, 1, socket.IPPROTO_TCP,
+                        '', ('127.0.0.1', 5672))],
+                    [(socket.AF_INET6, 1, socket.IPPROTO_TCP,
+                        '', ('::1', 5672))]
+                ]) as getaddrinfo:
+            self.t.sock = Mock()
+            self.t.close()
+            with patch.object(sock_mock.return_value, 'connect',
+                            side_effect=(socket.error, None)):
+                self.t.connect()
+            getaddrinfo.assert_has_calls(
+                [call('localhost', 5672, addr_type, ANY, ANY)
+                for addr_type in (socket.AF_INET, socket.AF_INET6)])
+
+    def test_connect_getaddrinfo_raises_gaierror(self):
+        with patch('socket.getaddrinfo', side_effect=socket.gaierror) as getaddrinfo:
+            with pytest.raises(socket.error):
+                self.t.connect()
+
+    def test_connect_getaddrinfo_raises_gaierror_once_recovers(self):
+        with patch('socket.socket', return_value=MockSocket()), \
+            patch('socket.getaddrinfo',
+                side_effect=[
+                    socket.gaierror,
+                    [(socket.AF_INET6, 1, socket.IPPROTO_TCP,
+                        '', ('::1', 5672))]
+                ]):
             self.t.connect()
 
-    @patch('socket.socket', return_value=MockSocket())
-    @patch('socket.getaddrinfo',
-           side_effect=[
-               [(socket.AF_INET, 1, socket.IPPROTO_TCP,
-                 '', ('127.0.0.1', 5672))],
-               [(socket.AF_INET6, 1, socket.IPPROTO_TCP,
-                 '', ('::1', 5672))]
-           ])
-    def test_connect_short_curcuit_on_INET_succeed(self, getaddrinfo,
-                                                   sock_mock):
-        self.t.sock = Mock()
-        self.t.close()
-        self.t.connect()
-        getaddrinfo.assert_called_with(
-            'localhost', 5672, socket.AF_INET, ANY, ANY)
-
-    @patch('socket.socket', return_value=MockSocket())
-    @patch('socket.getaddrinfo',
-           side_effect=[
-               [(socket.AF_INET, 1, socket.IPPROTO_TCP,
-                 '', ('127.0.0.1', 5672))],
-               [(socket.AF_INET6, 1, socket.IPPROTO_TCP,
-                 '', ('::1', 5672))]
-           ])
-    def test_connect_short_curcuit_on_INET_fails(self, getaddrinfo, sock_mock):
-        self.t.sock = Mock()
-        self.t.close()
-        with patch.object(sock_mock.return_value, 'connect',
-                          side_effect=(socket.error, None)):
-            self.t.connect()
-        getaddrinfo.assert_has_calls(
-            [call('localhost', 5672, addr_type, ANY, ANY)
-             for addr_type in (socket.AF_INET, socket.AF_INET6)])
-
-    @patch('socket.getaddrinfo', side_effect=socket.gaierror)
-    def test_connect_getaddrinfo_raises_gaierror(self, getaddrinfo):
-        with pytest.raises(socket.error):
-            self.t.connect()
-
-    @patch('socket.socket', return_value=MockSocket())
-    @patch('socket.getaddrinfo',
-           side_effect=[
-               socket.gaierror,
-               [(socket.AF_INET6, 1, socket.IPPROTO_TCP,
-                 '', ('::1', 5672))]
-           ])
-    def test_connect_getaddrinfo_raises_gaierror_once_recovers(self, *mocks):
-        self.t.connect()
-
-    @patch('socket.socket', return_value=MockSocket())
-    @patch('socket.getaddrinfo',
-           return_value=[(socket.AF_INET, 1, socket.IPPROTO_TCP,
-                          '', ('127.0.0.1', 5672))])
-    def test_connect_survives_not_implemented_set_cloexec(self, *mocks):
-        with patch('amqp.transport.set_cloexec',
-                   side_effect=NotImplementedError) as cloexec_mock:
-            self.t.connect()
-        assert cloexec_mock.called
+    def test_connect_survives_not_implemented_set_cloexec(self):
+        with patch('socket.socket', return_value=MockSocket()), \
+            patch('socket.getaddrinfo',
+                return_value=[(socket.AF_INET, 1, socket.IPPROTO_TCP,
+                                '', ('127.0.0.1', 5672))]):
+            with patch('amqp.transport.set_cloexec',
+                    side_effect=NotImplementedError) as cloexec_mock:
+                self.t.connect()
+            assert cloexec_mock.called
 
     def test_having_timeout_none(self):
         with self.t.having_timeout(None) as actual_sock:
@@ -472,14 +472,14 @@ class test_SSLTransport:
         self.t._wrap_socket(sock, {'c': 2}, foo=1)
         self.t._wrap_context.assert_called_with(sock, {'foo': 1}, c=2)
 
-    @patch('ssl.create_default_context', create=True)
-    def test_wrap_context(self, create_default_context):
-        sock = Mock()
-        self.t._wrap_context(sock, {'f': 1}, check_hostname=True, bar=3)
-        create_default_context.assert_called_with(bar=3)
-        ctx = create_default_context()
-        assert ctx.check_hostname
-        ctx.wrap_socket.assert_called_with(sock, f=1)
+    def test_wrap_context(self):
+        with patch('ssl.create_default_context', create=True) as create_default_context:
+            sock = Mock()
+            self.t._wrap_context(sock, {'f': 1}, check_hostname=True, bar=3)
+            create_default_context.assert_called_with(bar=3)
+            ctx = create_default_context()
+            assert ctx.check_hostname
+            ctx.wrap_socket.assert_called_with(sock, f=1)
 
     def test_shutdown_transport(self):
         self.t.sock = None

--- a/t/unit/test_utils.py
+++ b/t/unit/test_utils.py
@@ -71,16 +71,16 @@ class test_NullHandler:
 
 class test_get_logger:
 
-    @patch('logging.getLogger')
-    def test_as_str(self, getLogger):
-        x = get_logger('foo.bar')
-        getLogger.assert_called_with('foo.bar')
-        assert x is getLogger()
+    def test_as_str(self):
+        with patch('logging.getLogger') as getLogger:
+            x = get_logger('foo.bar')
+            getLogger.assert_called_with('foo.bar')
+            assert x is getLogger()
 
-    @patch('amqp.utils.NullHandler')
-    def test_as_logger(self, _NullHandler):
-        m = Mock(name='logger')
-        m.handlers = None
-        x = get_logger(m)
-        assert x is m
-        x.addHandler.assert_called_with(_NullHandler())
+    def test_as_logger(self):
+        with patch('amqp.utils.NullHandler') as _NullHandler:
+            m = Mock(name='logger')
+            m.handlers = None
+            x = get_logger(m)
+            assert x is m
+            x.addHandler.assert_called_with(_NullHandler())


### PR DESCRIPTION
The @patch decorator clashes with (some version of?) py.test's fixture support
because py.test tries to interpret the argument names as fixtures and doesn't 
know about @patch filling the slots.

Rather than performing deep hackery, teaching either of these tools to work
that way, this change elects to simply replace these decorators with
"with patch() …" constructs.