### PR TITLE
for deserialisation, correct offset for bits

### DIFF
--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -165,11 +165,12 @@ def loads(format, buf, offset=0,
         if p == 'b':
             if not bitcount:
                 bits = ord(buf[offset:offset + 1])
+                offset += 1
             bitcount = 8
             val = (bits & 1) == 1
             bits >>= 1
             bitcount -= 1
-            offset += 1
+
         elif p == 'o':
             bitcount = bits = 0
             val, = unpack_from('>B', buf, offset)

--- a/t/unit/test_serialization.py
+++ b/t/unit/test_serialization.py
@@ -97,7 +97,8 @@ class test_serialization:
             dumps('A', [[object()]])
 
     def test_bit_offset_adjusted_correctly(self):
-        buf = dumps('BssbbbbbF', [50, "quick", "fox", True, False, False, True, True, {"prop1": True}])
+        buf = dumps('BssbbbbbF', [50, "quick", "fox", True,
+                                  False, False, True, True, {"prop1": True}])
         loads('BssbbbbbF', buf)
 
 

--- a/t/unit/test_serialization.py
+++ b/t/unit/test_serialization.py
@@ -96,6 +96,10 @@ class test_serialization:
         with pytest.raises(FrameSyntaxError):
             dumps('A', [[object()]])
 
+    def test_bit_offset_adjusted_correctly(self):
+        buf = dumps('BssbbbbbF', [50, "quick", "fox", True, False, False, True, True, {"prop1": True}])
+        loads('BssbbbbbF', buf)
+
 
 class test_GenericContent:
 

--- a/t/unit/test_serialization.py
+++ b/t/unit/test_serialization.py
@@ -97,9 +97,11 @@ class test_serialization:
             dumps('A', [[object()]])
 
     def test_bit_offset_adjusted_correctly(self):
-        buf = dumps('BssbbbbbF', [50, "quick", "fox", True,
-                                  False, False, True, True, {"prop1": True}])
-        loads('BssbbbbbF', buf)
+        expected = [50, "quick", "fox", True,
+                    False, False, True, True, {"prop1": True}]
+        buf = dumps('BssbbbbbF', expected)
+        actual, _ = loads('BssbbbbbF', buf)
+        assert actual == expected
 
 
 class test_GenericContent:


### PR DESCRIPTION
it needs to be increased only at the beginning and once every 8 bits

otherwise typically it was failling to decode "queue.declare" 