### PR TITLE
remove socket option TCP_USER_TIMEOUT for osx, fixes #193 #193

### DIFF
--- a/amqp/platform.py
+++ b/amqp/platform.py
@@ -48,6 +48,8 @@ if sys.platform.startswith('linux'):
     if platform.release().endswith("Microsoft"):
         KNOWN_TCP_OPTS = {'TCP_NODELAY', 'TCP_KEEPIDLE', 'TCP_KEEPINTVL',
                           'TCP_KEEPCNT'}
+if sys.platform.startswith('darwin'):
+    KNOWN_TCP_OPTS.remove('TCP_USER_TIMEOUT')
 
 # According to MSDN Windows platforms support getsockopt(TCP_MAXSSEG) but not
 # setsockopt(TCP_MAXSEG) on IPPROTO_TCP sockets.

--- a/amqp/platform.py
+++ b/amqp/platform.py
@@ -48,7 +48,7 @@ if sys.platform.startswith('linux'):
     if platform.release().endswith("Microsoft"):
         KNOWN_TCP_OPTS = {'TCP_NODELAY', 'TCP_KEEPIDLE', 'TCP_KEEPINTVL',
                           'TCP_KEEPCNT'}
-if sys.platform.startswith('darwin'):
+elif sys.platform.startswith('darwin'):
     KNOWN_TCP_OPTS.remove('TCP_USER_TIMEOUT')
 
 # According to MSDN Windows platforms support getsockopt(TCP_MAXSSEG) but not


### PR DESCRIPTION
The issue was that OSX does not support the `TCP_USER_TIMEOUT` option.