### PR TITLE
Fix encoding errors

### DIFF
--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from . import spec
 from .basic_message import Message
 from .exceptions import UnexpectedFrame
-from .five import range
+from .five import range, text_t
 from .platform import pack, pack_into, unpack_from
 from .utils import str_to_bytes
 
@@ -85,7 +85,7 @@ def frame_handler(connection, callback,
 
 def frame_writer(connection, transport,
                  pack=pack, pack_into=pack_into, range=range, len=len,
-                 bytes=bytes, str_to_bytes=str_to_bytes):
+                 bytes=bytes, str_to_bytes=str_to_bytes, text_t=text_t):
     """Create closure that writes frames."""
     write = transport.write
 
@@ -101,8 +101,10 @@ def frame_writer(connection, transport,
         properties = None
         args = str_to_bytes(args)
         if content:
-            properties = content._serialize_properties()
             body = content.body
+            if isinstance(body, text_t):
+                content.properties.setdefault('content_encoding', 'utf-8')
+            properties = content._serialize_properties()
             bodylen = len(body)
             framelen = (
                 len(args) +

--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -104,6 +104,7 @@ def frame_writer(connection, transport,
             body = content.body
             if isinstance(body, text_t):
                 content.properties.setdefault('content_encoding', 'utf-8')
+            body = str_to_bytes(body)
             properties = content._serialize_properties()
             bodylen = len(body)
             framelen = (
@@ -137,7 +138,7 @@ def frame_writer(connection, transport,
                     framelen = len(frame)
                     write(pack('>BHI%dsB' % framelen,
                                3, channel, framelen,
-                               str_to_bytes(frame), 0xce))
+                               frame, 0xce))
 
         else:
             # ## FAST: pack into buffer and single write
@@ -162,7 +163,7 @@ def frame_writer(connection, transport,
                 if bodylen > 0:
                     framelen = bodylen
                     pack_into('>BHI%dsB' % framelen, buf, offset,
-                              3, channel, framelen, str_to_bytes(body), 0xce)
+                              3, channel, framelen, body, 0xce)
                     offset += 8 + framelen
 
             write(view[:offset])

--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -103,8 +103,9 @@ def frame_writer(connection, transport,
         if content:
             body = content.body
             if isinstance(body, text_t):
-                content.properties.setdefault('content_encoding', 'utf-8')
-            body = str_to_bytes(body)
+                encoding = content.properties.setdefault(
+                    'content_encoding', 'utf-8')
+                body = body.encode(encoding)
             properties = content._serialize_properties()
             bodylen = len(body)
             framelen = (

--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -520,7 +520,6 @@ class GenericContent(object):
         flags = []
         sformat, svalues = [], []
         props = self.properties
-        props.setdefault('content_encoding', 'utf-8')
         for key, proptype in self.PROPERTIES:
             val = props.get(key, None)
             if val is not None:

--- a/t/unit/test_method_framing.py
+++ b/t/unit/test_method_framing.py
@@ -92,15 +92,18 @@ class test_frame_writer:
         frame = 2, 1, spec.Basic.Publish, b'x' * 10, msg
         self.g(*frame)
         self.write.assert_called()
+        assert 'content_encoding' not in msg.properties
 
     def test_write_slow_content(self):
         msg = Message(body=b'y' * 2048, content_type='utf-8')
         frame = 2, 1, spec.Basic.Publish, b'x' * 10, msg
         self.g(*frame)
         self.write.assert_called()
+        assert 'content_encoding' not in msg.properties
 
     def test_write_zero_len_body(self):
         msg = Message(body=b'', content_type='application/octet-stream')
         frame = 2, 1, spec.Basic.Publish, b'x' * 10, msg
         self.g(*frame)
         self.write.assert_called()
+        assert 'content_encoding' not in msg.properties

--- a/t/unit/test_method_framing.py
+++ b/t/unit/test_method_framing.py
@@ -127,3 +127,13 @@ class test_frame_writer:
         assert isinstance(memory, bytes)
         assert '\N{CHECK MARK}'.encode('utf-8') in memory
         assert msg.properties['content_encoding'] == 'utf-8'
+
+    def test_write_non_utf8(self):
+        msg = Message(body='body', content_encoding='utf-16')
+        frame = 2, 1, spec.Basic.Publish, b'x' * 10, msg
+        self.g(*frame)
+        self.write.assert_called()
+        memory = self.write.call_args[0][0]
+        assert isinstance(memory, memoryview)
+        assert 'body'.encode('utf-16') in memory.tobytes()
+        assert msg.properties['content_encoding'] == 'utf-16'


### PR DESCRIPTION
This PR fixes three distinct but related issues. All three of these are regressions from amqp 1.4; the previous behavior can be seen here: https://github.com/celery/py-amqp/blob/611f6ac990692ef5a92b4ecf255f9d4132d29d68/amqp/method_framing.py#L208-L219