### PR TITLE
Handle negative acknowledgments sent by RMQ

### DIFF
--- a/amqp/abstract_channel.py
+++ b/amqp/abstract_channel.py
@@ -106,17 +106,13 @@ class AbstractChannel(object):
         try:
             listeners = [self._callbacks[method_sig]]
         except KeyError:
-            listeners = None
+            listeners = []
+        one_shot = None
         try:
             one_shot = self._pending.pop(method_sig)
         except KeyError:
             if not listeners:
                 return
-        else:
-            if listeners is None:
-                listeners = [one_shot]
-            else:
-                listeners.append(one_shot)
 
         args = []
         if amqp_method.args:
@@ -126,6 +122,9 @@ class AbstractChannel(object):
 
         for listener in listeners:
             listener(*args)
+
+        if one_shot:
+            one_shot(method_sig, *args)
 
     #: Placeholder, the concrete implementations will have to
     #: supply their own versions of _METHOD_MAP

--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -13,7 +13,7 @@ from . import spec
 from .abstract_channel import AbstractChannel
 from .exceptions import (ChannelError, ConsumerCancelled,
                          RecoverableChannelError, RecoverableConnectionError,
-                         error_for_code)
+                         error_for_code, MessageNacked)
 from .five import Queue
 from .protocol import queue_declare_ok_t
 
@@ -30,10 +30,6 @@ REJECTED_MESSAGE_WITHOUT_CALLBACK = """\
 Rejecting message with delivery tag %r for reason of having no callbacks.
 consumer_tag=%r exchange=%r routing_key=%r.\
 """
-
-
-class MessageNacked(Exception):
-    pass
 
 
 class VDeprecationWarning(DeprecationWarning):

--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -31,6 +31,7 @@ Rejecting message with delivery tag %r for reason of having no callbacks.
 consumer_tag=%r exchange=%r routing_key=%r.\
 """
 
+
 class MessageNacked(Exception):
     pass
 
@@ -1739,7 +1740,6 @@ class Channel(AbstractChannel):
         except socket.timeout:
             raise RecoverableChannelError('basic_publish: timed out')
     basic_publish = _basic_publish
-
 
     def basic_publish_confirm(self, *args, **kwargs):
 

--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -2058,4 +2058,4 @@ class Channel(AbstractChannel):
 
     def _on_basic_nack(self, delivery_tag, multiple):
         for callback in self.events['basic_nack']:
-            callback(delivery_tag, multiple, spec.basic.Nack)
+            callback(delivery_tag, multiple)

--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -1671,6 +1671,11 @@ class Channel(AbstractChannel):
         configuration and distributed to any active consumers when the
         transaction, if any, is committed.
 
+        When channel is in confirm mode (when Connection parameter
+        confirm_publish is set to True), each message is confirmed. When
+        broker rejects published message (e.g. due internal broker
+        constrains), MessageNacked exception is raised.
+
         PARAMETERS:
             exchange: shortstr
 

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -97,6 +97,10 @@ class Connection(AbstractChannel):
 
     The "socket_settings" parameter is a dictionary defining tcp
     settings which will be applied as socket options.
+
+    When "confirm_publish" is set to True, the channel is put to
+    confirm mode. In this mode, each published message is
+    confirmed using Publisher confirms RabbitMQ extention.
     """
 
     Channel = Channel

--- a/amqp/exceptions.py
+++ b/amqp/exceptions.py
@@ -26,7 +26,6 @@ class AMQPDeprecationWarning(UserWarning):
 
 class MessageNacked(Exception):
     """Message was nacked by broker."""
-    pass
 
 
 @python_2_unicode_compatible

--- a/amqp/exceptions.py
+++ b/amqp/exceptions.py
@@ -23,6 +23,7 @@ __all__ = [
 class AMQPDeprecationWarning(UserWarning):
     """Warning for deprecated things."""
 
+
 class MessageNacked(Exception):
     """Message was nacked by broker."""
     pass

--- a/amqp/exceptions.py
+++ b/amqp/exceptions.py
@@ -15,13 +15,17 @@ __all__ = [
     'ResourceLocked', 'PreconditionFailed', 'FrameError', 'FrameSyntaxError',
     'InvalidCommand', 'ChannelNotOpen', 'UnexpectedFrame', 'ResourceError',
     'NotAllowed', 'AMQPNotImplementedError', 'InternalError',
-
+    'MessageNacked',
     'AMQPDeprecationWarning',
 ]
 
 
 class AMQPDeprecationWarning(UserWarning):
     """Warning for deprecated things."""
+
+class MessageNacked(Exception):
+    """Message was nacked by broker."""
+    pass
 
 
 @python_2_unicode_compatible

--- a/t/unit/test_abstract_channel.py
+++ b/t/unit/test_abstract_channel.py
@@ -97,14 +97,14 @@ class test_AbstractChannel:
         self.method.args = None
         p = self.c._pending[(50, 61)] = Mock(name='oneshot')
         self.c.dispatch_method((50, 61), 'payload', self.content)
-        p.assert_called_with(self.content)
+        p.assert_called_with((50, 61), self.content)
 
     def test_dispatch_method__one_shot_no_content(self):
         self.method.args = None
         self.method.content = None
         p = self.c._pending[(50, 61)] = Mock(name='oneshot')
         self.c.dispatch_method((50, 61), 'payload', self.content)
-        p.assert_called_with()
+        p.assert_called_with((50, 61))
         assert not self.c._pending
 
     def test_dispatch_method__listeners(self):
@@ -121,6 +121,6 @@ class test_AbstractChannel:
             p2 = self.c._pending[(50, 61)] = Mock(name='oneshot')
             self.c.dispatch_method((50, 61), 'payload', self.content)
             p1.assert_called_with(1, 2, 3, self.content)
-            p2.assert_called_with(1, 2, 3, self.content)
+            p2.assert_called_with((50, 61), 1, 2, 3, self.content)
             assert not self.c._pending
             assert self.c._callbacks[(50, 61)]

--- a/t/unit/test_channel.py
+++ b/t/unit/test_channel.py
@@ -336,7 +336,9 @@ class test_Channel:
         assert self.c._confirm_selected
         self.c._basic_publish.assert_called_with(1, 2, arg=1)
         assert ret is self.c._basic_publish()
-        self.c.wait.assert_called_with([spec.Basic.Ack, spec.Basic.Nack], callback=ANY)
+        self.c.wait.assert_called_with(
+            [spec.Basic.Ack, spec.Basic.Nack], callback=ANY
+        )
         self.c.basic_publish_confirm(1, 2, arg=1)
 
     def test_basic_publish_confirm_nack(self):

--- a/t/unit/test_channel.py
+++ b/t/unit/test_channel.py
@@ -434,3 +434,9 @@ class test_Channel:
         self.c.events['basic_ack'].add(callback)
         self.c._on_basic_ack(123, True)
         callback.assert_called_with(123, True)
+
+    def test_on_basic_nack(self):
+        callback = Mock(name='callback')
+        self.c.events['basic_nack'].add(callback)
+        self.c._on_basic_nack(123, True)
+        callback.assert_called_with(123, True)

--- a/t/unit/test_channel.py
+++ b/t/unit/test_channel.py
@@ -6,8 +6,8 @@ from case import ContextMock, Mock, patch, ANY
 from amqp import spec
 from amqp.platform import pack
 from amqp.serialization import dumps
-from amqp.channel import Channel, MessageNacked
-from amqp.exceptions import ConsumerCancelled, NotFound
+from amqp.channel import Channel
+from amqp.exceptions import ConsumerCancelled, NotFound, MessageNacked
 
 
 class test_Channel:


### PR DESCRIPTION
This PR fixes #207. This PR:
* adds nack specs and callbacks to channel
* adds nack method and callback in `channel.wait()`
* `channel.wait()` callbacks now has AMQP method as first parameter
* `channel.basic_publish_confirm()` now raises `MessageNacked` exception when library receives Nack when waiting for confirmation