### PR TITLE
Issue#209: Connection.connect, Connection.close don't close socket on exception

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -309,8 +309,8 @@ class Connection(AbstractChannel):
                 self.drain_events(timeout=self.connect_timeout)
 
             return callback() if callback else None
-        except (OSError, IOError, SSLError) as e:
-            self.collect ()
+        except (OSError, IOError, SSLError):
+            self.collect()
             raise
 
     def _warn_force_connect(self, attr):
@@ -571,10 +571,10 @@ class Connection(AbstractChannel):
                 (reply_code, reply_text, method_sig[0], method_sig[1]),
                 wait=spec.Connection.CloseOk,
             )
-        except (OSError, IOError, SSLError) as e:
-          ### close connection
-          self.collect ()
-          raise
+        except (OSError, IOError, SSLError):
+            # close connection
+            self.collect()
+            raise
 
     def _on_close(self, reply_code, reply_text, class_id, method_id):
         """Request a connection close.

--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -308,7 +308,6 @@ class Connection(AbstractChannel):
             while not self._handshake_complete:
                 self.drain_events(timeout=self.connect_timeout)
 
-            return callback() if callback else None
         except (OSError, IOError, SSLError):
             self.collect()
             raise

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -377,7 +377,7 @@ class SSLTransport(_AbstractTransport):
                         continue
                     raise
                 if not s:
-                    raise IOError('Socket closed')
+                    raise IOError('Server unexpectedly closed connection')
                 rbuf += s
         except:  # noqa
             self._read_buffer = rbuf

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -430,7 +430,7 @@ class TCPTransport(_AbstractTransport):
                         continue
                     raise
                 if not s:
-                    raise IOError('Socket closed')
+                    raise IOError('Server unexpectedly closed connection')
                 rbuf += s
         except:  # noqa
             self._read_buffer = rbuf

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -60,12 +60,10 @@ def to_host_port(host, default=AMQP_PORT):
 class _AbstractTransport(object):
     """Common superclass for TCP and SSL transports."""
 
-    connected = False
-
     def __init__(self, host, connect_timeout=None,
                  read_timeout=None, write_timeout=None,
                  socket_settings=None, raise_on_initial_eintr=True, **kwargs):
-        self.connected = True
+        self.connected = False
         self.sock = None
         self.raise_on_initial_eintr = raise_on_initial_eintr
         self._read_buffer = EMPTY_BUFFER
@@ -76,10 +74,24 @@ class _AbstractTransport(object):
         self.socket_settings = socket_settings
 
     def connect(self):
-        self._connect(self.host, self.port, self.connect_timeout)
-        self._init_socket(
-            self.socket_settings, self.read_timeout, self.write_timeout,
-        )
+        try:
+            ### are we already connected?
+            if self.connected:
+              return
+            self._connect(self.host, self.port, self.connect_timeout)
+            self._init_socket(
+                self.socket_settings, self.read_timeout, self.write_timeout,
+            )
+            # we've sent the banner; signal connect
+            # EINTR, EAGAIN, EWOULDBLOCK would signal that the banner
+            # has _not_ been sent
+            self.connected = True
+        except (OSError, IOError, SSLError) as e:
+            # if not fully connected, close socket, and reraise error
+            if self.sock and not self.connected:
+                self.sock.close ()
+                self.sock = None
+            raise
 
     @contextmanager
     def having_timeout(self, timeout):
@@ -160,26 +172,21 @@ class _AbstractTransport(object):
                     return
 
     def _init_socket(self, socket_settings, read_timeout, write_timeout):
-        try:
-            self.sock.settimeout(None)  # set socket back to blocking mode
-            self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
-            self._set_socket_options(socket_settings)
+        self.sock.settimeout(None)  # set socket back to blocking mode
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        self._set_socket_options(socket_settings)
 
-            # set socket timeouts
-            for timeout, interval in ((socket.SO_SNDTIMEO, write_timeout),
-                                      (socket.SO_RCVTIMEO, read_timeout)):
-                if interval is not None:
-                    self.sock.setsockopt(
-                        socket.SOL_SOCKET, timeout,
-                        pack('ll', interval, 0),
-                    )
-            self._setup_transport()
+        # set socket timeouts
+        for timeout, interval in ((socket.SO_SNDTIMEO, write_timeout),
+                                  (socket.SO_RCVTIMEO, read_timeout)):
+            if interval is not None:
+                self.sock.setsockopt(
+                    socket.SOL_SOCKET, timeout,
+                    pack('ll', interval, 0),
+                )
+        self._setup_transport()
 
-            self._write(AMQP_PROTOCOL_HEADER)
-        except (OSError, IOError, socket.error) as exc:
-            if get_errno(exc) not in _UNAVAIL:
-                self.connected = False
-            raise
+        self._write(AMQP_PROTOCOL_HEADER)
 
     def _get_tcp_socket_defaults(self, sock):
         tcp_opts = {}

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -75,9 +75,9 @@ class _AbstractTransport(object):
 
     def connect(self):
         try:
-            ### are we already connected?
+            # are we already connected?
             if self.connected:
-              return
+                return
             self._connect(self.host, self.port, self.connect_timeout)
             self._init_socket(
                 self.socket_settings, self.read_timeout, self.write_timeout,
@@ -86,10 +86,10 @@ class _AbstractTransport(object):
             # EINTR, EAGAIN, EWOULDBLOCK would signal that the banner
             # has _not_ been sent
             self.connected = True
-        except (OSError, IOError, SSLError) as e:
+        except (OSError, IOError, SSLError):
             # if not fully connected, close socket, and reraise error
             if self.sock and not self.connected:
-                self.sock.close ()
+                self.sock.close()
                 self.sock = None
             raise
 

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -4,7 +4,7 @@ import socket
 import warnings
 
 import pytest
-from case import ContextMock, Mock, call
+from case import ContextMock, Mock, call, patch
 
 from amqp import Connection, spec
 from amqp.connection import SSLError
@@ -126,6 +126,14 @@ class test_Connection:
         self.conn.transport.connected = True
         assert self.conn.connect(callback) == callback.return_value
         callback.assert_called_with()
+
+    def test_connect__socket_error(self):
+        self.conn = Connection ()
+        self.conn.collect=Mock(name='collect')
+        with patch('socket.socket', side_effect=socket.error): 
+            with pytest.raises(socket.error):   
+                self.conn.connect ()
+        self.conn.collect.assert_called_with ()
 
     def test_on_start(self):
         self.conn._on_start(3, 4, {'foo': 'bar'}, b'x y z AMQPLAIN PLAIN',
@@ -279,6 +287,7 @@ class test_Connection:
         for i, channel in items(channels):
             if i:
                 channel.collect.assert_called_with()
+        assert self.conn._transport is None
 
     def test_collect__channel_raises_socket_error(self):
         self.conn.channels = self.conn.channels = {1: Mock(name='c1')}
@@ -376,16 +385,27 @@ class test_Connection:
         )
 
     def test_close(self):
+        self.conn.collect=Mock(name='collect')
         self.conn.close(reply_text='foo', method_sig=spec.Channel.Open)
         self.conn.send_method.assert_called_with(
             spec.Connection.Close, 'BsBB',
             (0, 'foo', spec.Channel.Open[0], spec.Channel.Open[1]),
             wait=spec.Connection.CloseOk,
         )
+        self.conn.collect.assert_called_with
 
     def test_close__already_closed(self):
         self.conn.transport = None
         self.conn.close()
+
+    def test_close__socket_error(self):
+        self.conn.send_method = Mock(name='send_method',
+                                     side_effect=socket.error)
+        self.conn.collect = Mock(name='collect')
+        with pytest.raises(socket.error):   
+          self.conn.close()
+        self.conn.send_method.assert_called()
+        self.conn.collect.assert_called_with()
 
     def test_on_close(self):
         self.conn._x_close_ok = Mock(name='_x_close_ok')

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -242,8 +242,9 @@ class test_AbstractTransport:
         self.t.close()
         sock.shutdown.assert_called_with(socket.SHUT_RDWR)
         sock.close.assert_called_with()
-        assert self.t.sock is None
+        assert self.t.sock is None and self.t.connected is False
         self.t.close()
+        assert self.t.sock is None and self.t.connected is False
 
     def test_read_frame__timeout(self):
         self.t._read = Mock()
@@ -350,6 +351,7 @@ class test_AbstractTransport_connect:
         with patch('socket.socket', side_effect=socket.error):
             with pytest.raises(socket.error):
                 self.t.connect()
+        assert self.t.sock is None and self.t.connected is False
 
     def test_connect_socket_initialization_fails(self):
         with patch('socket.socket', side_effect=socket.error), \
@@ -362,6 +364,7 @@ class test_AbstractTransport_connect:
                   ]):
             with pytest.raises(socket.error):
                 self.t.connect()
+            assert self.t.sock is None and self.t.connected is False
 
     def test_connect_multiple_addr_entries_fails(self):
         with patch('socket.socket', return_value=MockSocket()) as sock_mock, \

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -21,8 +21,8 @@ class MockSocket(object):
         self.sa = None
 
     def setsockopt(self, family, key, value):
-        if family == socket.SOL_SOCKET and
-               key in (socket.SO_RCVTIMEO, socket.SO_SNDTIMEO):
+        if (family == socket.SOL_SOCKET and
+                key in (socket.SO_RCVTIMEO, socket.SO_SNDTIMEO)):
             self.options[key] = value
         elif not isinstance(value, int):
             raise socket.error()
@@ -215,12 +215,8 @@ class test_socket_options:
         self.transp.read_timeout = 0xdead
         self.transp.write_timeout = 0xbeef
         with patch('socket.socket', return_value=MockSocket()):
-<<<<<<< HEAD
             self.transp.connect()
 
-=======
-          self.transp.connect()
->>>>>>> 9c23527645a8c0bf734cf418d46037fc36fdfb44
 
 class test_AbstractTransport:
 
@@ -322,21 +318,12 @@ class test_AbstractTransport:
     def transport_read_EOF(self):
         for host, ssl in (('localhost:5672', False),
                           ('localhost:5671', True),):
-<<<<<<< HEAD
             self.t = transport.Transport(host, ssl)
             self.t.sock = Mock(name='socket')
             self.t.connected = True
             self.t._quick_recv = Mock(name='recv', return_value='')
             with pytest.raises(IOError,
                      match=r'.*Server unexpectedly closed connection.*'):
-=======
-            self.t = transport.Transport (host, ssl)
-            self.t.sock = Mock (name='socket')
-            self.t.connected = True
-            self.t._quick_recv = Mock(name='recv', return_value='')
-            with pytest.raises(IOError,
-                match=r'.*Server unexpectedly closed connection.*'):
->>>>>>> 9c23527645a8c0bf734cf418d46037fc36fdfb44
                 self.t.read_frame()
 
     def test_write__success(self):

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -322,8 +322,10 @@ class test_AbstractTransport:
             self.t.sock = Mock(name='socket')
             self.t.connected = True
             self.t._quick_recv = Mock(name='recv', return_value='')
-            with pytest.raises(IOError,
-                     match=r'.*Server unexpectedly closed connection.*'):
+            with pytest.raises(
+                IOError,
+                match=r'.*Server unexpectedly closed connection.*'
+            ):
                 self.t.read_frame()
 
     def test_write__success(self):


### PR DESCRIPTION
This PR resolves the problem discussed in Issue#209. In summary, the problem is that an exception during Connection.open, Connection.close leaves the socket open. The PR addresses the problem by appropriately closing the socket when an exception is encountered.