### PR TITLE
Drain events before publish data.

### DIFF
--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -1732,6 +1732,15 @@ class Channel(AbstractChannel):
         if not self.connection:
             raise RecoverableConnectionError(
                 'basic_publish: connection closed')
+
+        client_properties = self.connection.client_properties
+        if client_properties['capabilities']['connection.blocked']:
+            try:
+                # Check if an event was sent, such as the out of memory message
+                self.connection.drain_events(timeout=0)
+            except socket.timeout:
+                pass
+
         try:
             with self.connection.transport.having_timeout(timeout):
                 return self.send_method(

--- a/t/unit/test_channel.py
+++ b/t/unit/test_channel.py
@@ -367,7 +367,7 @@ class test_Channel:
                 spec.Basic.Nack, frame, None
             )
 
-    def test_connection_blocked(self):
+    def test_basic_publish_connection_blocked(self):
         # Basic test checking that drain_events() is called
         # before publishing message and send_method() is called
         self.c._basic_publish('msg', 'ex', 'rkey')
@@ -388,7 +388,7 @@ class test_Channel:
             (0, 'ex', 'rkey', False, False), 'msg',
         )
 
-    def test_connection_blocked_not_supported(self):
+    def test_basic_publish_connection_blocked_not_supported(self):
         # Test veryfying that when server does not have
         # connection.blocked capability, drain_events() are not called
         self.conn.client_properties = {
@@ -403,7 +403,7 @@ class test_Channel:
             (0, 'ex', 'rkey', False, False), 'msg',
         )
 
-    def test_basic_publsh_confirm_callback(self):
+    def test_basic_publish_confirm_callback(self):
 
         def wait_nack(method, *args, **kwargs):
             kwargs['callback'](spec.Basic.Nack)

--- a/t/unit/test_channel.py
+++ b/t/unit/test_channel.py
@@ -369,8 +369,8 @@ class test_Channel:
 
     def test_connection_blocked(self):
         self.c._basic_publish('msg', 'ex', 'rkey')
-        self.conn.drain_events.assert_called_with(timeout=0)
-        self.c.send_method.assert_called_with(
+        self.conn.drain_events.assert_called_once_with(timeout=0)
+        self.c.send_method.assert_called_once_with(
             spec.Basic.Publish, 'Bssbb',
             (0, 'ex', 'rkey', False, False), 'msg',
         )
@@ -379,7 +379,7 @@ class test_Channel:
 
         self.conn.drain_events.side_effect = socket.timeout
         self.c._basic_publish('msg', 'ex', 'rkey')
-        self.c.send_method.assert_called_with(
+        self.c.send_method.assert_called_once_with(
             spec.Basic.Publish, 'Bssbb',
             (0, 'ex', 'rkey', False, False), 'msg',
         )


### PR DESCRIPTION
Data are drained to checked if server sent connection blocked/unblocked notification. This is the fixed PR #115.  PR #213 also adds additional integration tests.