### PR TITLE
Improved empty AMQPError string representation

### DIFF
--- a/amqp/exceptions.py
+++ b/amqp/exceptions.py
@@ -49,7 +49,9 @@ class AMQPError(Exception):
     def __str__(self):
         if self.method:
             return '{0.method}: ({0.reply_code}) {0.reply_text}'.format(self)
-        return self.reply_text or '<AMQPError: unknown error>'
+        return self.reply_text or '<{}: unknown error>'.format(
+            type(self).__name__
+        )
 
     @property
     def method(self):

--- a/t/unit/test_exceptions.py
+++ b/t/unit/test_exceptions.py
@@ -1,16 +1,37 @@
 from __future__ import absolute_import, unicode_literals
 
 from case import Mock
+import pytest
 
+import amqp.exceptions
 from amqp.exceptions import AMQPError, error_for_code
+
+AMQP_EXCEPTIONS = [
+    'ConnectionError', 'ChannelError',
+    'RecoverableConnectionError', 'IrrecoverableConnectionError',
+    'RecoverableChannelError', 'IrrecoverableChannelError',
+    'ConsumerCancelled', 'ContentTooLarge', 'NoConsumers',
+    'ConnectionForced', 'InvalidPath', 'AccessRefused', 'NotFound',
+    'ResourceLocked', 'PreconditionFailed', 'FrameError', 'FrameSyntaxError',
+    'InvalidCommand', 'ChannelNotOpen', 'UnexpectedFrame', 'ResourceError',
+    'NotAllowed', 'AMQPNotImplementedError', 'InternalError',
+]
 
 
 class test_AMQPError:
 
     def test_str(self):
-        assert str(AMQPError())
+        assert str(AMQPError()) == '<AMQPError: unknown error>'
         x = AMQPError(method_sig=(50, 60))
-        assert str(x)
+        assert str(x) == '(50, 60): (0) None'
+        x = AMQPError('Test Exception')
+        assert str(x) == 'Test Exception'
+
+    @pytest.mark.parametrize("amqp_exception", AMQP_EXCEPTIONS)
+    def test_str_subclass(self, amqp_exception):
+        exp = '<{}: unknown error>'.format(amqp_exception)
+        exception_class = getattr(amqp.exceptions, amqp_exception)
+        assert str(exception_class()) == exp
 
 
 class test_error_for_code:


### PR DESCRIPTION
Currently, `AMQPError` and all its subclasses created without parameters has same string representation:
```python
>>> import amqp
>>> raise amqp.AMQPError()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
amqp.exceptions.AMQPError: <AMQPError: unknown error>
>>> raise amqp.ChannelError()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
amqp.exceptions.ChannelError: <AMQPError: unknown error>
```
This can be confusing in logs for users - see comments # 28, # 19... in [1].

This PR proposes to generate current class of exception in each subclass of `AMQPError`:
```python
>>> import amqp
>>> raise amqp.AMQPError()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
amqp.exceptions.AMQPError: <AMQPError: unknown error>
>>> raise amqp.ChannelError()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
amqp.exceptions.ChannelError: <ChannelError: unknown error>
```

[1] https://bugs.launchpad.net/oslo.messaging/+bug/1800957