### PR TITLE
Move delivery_info to constructor of Message.

### DIFF
--- a/amqp/basic_message.py
+++ b/amqp/basic_message.py
@@ -102,11 +102,10 @@ class Message(GenericContent):
         ('cluster_id', 's')
     ]
 
-    #: set by basic_consume/basic_get
-    delivery_info = None
-
     def __init__(self, body='', children=None, channel=None, **properties):
         super(Message, self).__init__(**properties)
+        #: set by basic_consume/basic_get
+        self.delivery_info = None
         self.body = body
         self.channel = channel
 

--- a/t/unit/test_basic_message.py
+++ b/t/unit/test_basic_message.py
@@ -13,7 +13,8 @@ class test_Message:
             channel=Mock(name='channel'),
             application_headers={'h': 'v'},
         )
-        m.delivery_info = {'delivery_tag': '1234'},
+        m.delivery_info = {'delivery_tag': '1234'}
         assert m.body == 'foo'
         assert m.channel
         assert m.headers == {'h': 'v'}
+        assert m.delivery_tag == '1234'


### PR DESCRIPTION
This PR fixes delivery_info attribute of Message class which is defined as static attribute but is used as instance attribute. This PR also cleans and improves tests.