### PR TITLE
Fix crash in basic_publish when broker does not support connection.blocked capability

### DIFF
--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -1755,8 +1755,9 @@ class Channel(AbstractChannel):
             raise RecoverableConnectionError(
                 'basic_publish: connection closed')
 
-        client_properties = self.connection.client_properties
-        if client_properties['capabilities']['connection.blocked']:
+        capabilities = self.connection.\
+            client_properties.get('capabilities', {})
+        if capabilities.get('connection.blocked', False):
             try:
                 # Check if an event was sent, such as the out of memory message
                 self.connection.drain_events(timeout=0)

--- a/t/unit/test_channel.py
+++ b/t/unit/test_channel.py
@@ -469,6 +469,31 @@ class test_Channel:
             (0, 'ex', 'rkey', False, False), 'msg',
         )
 
+    def test_basic_publish_connection_blocked_not_supported_missing(self):
+        # Test veryfying that when server does not have
+        # connection.blocked capability, drain_events() are not called
+        self.conn.client_properties = {
+            'capabilities': {}
+        }
+        self.c._basic_publish('msg', 'ex', 'rkey')
+        self.conn.drain_events.assert_not_called()
+        self.c.send_method.assert_called_once_with(
+            spec.Basic.Publish, 'Bssbb',
+            (0, 'ex', 'rkey', False, False), 'msg',
+        )
+
+    def test_basic_publish_connection_blocked_no_capabilities(self):
+        # Test veryfying that when server does not have
+        # support of capabilities, drain_events() are not called
+        self.conn.client_properties = {
+        }
+        self.c._basic_publish('msg', 'ex', 'rkey')
+        self.conn.drain_events.assert_not_called()
+        self.c.send_method.assert_called_once_with(
+            spec.Basic.Publish, 'Bssbb',
+            (0, 'ex', 'rkey', False, False), 'msg',
+        )
+
     def test_basic_publish_confirm_callback(self):
 
         def wait_nack(method, *args, **kwargs):


### PR DESCRIPTION
This PR fix support of older brokers and brokers not supporting connection.blocked extension. Also adds bunch of new tests.

Closes #243 