### PR TITLE
When attempting to publish a message or start Celery worker amqp woul…

### DIFF
--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -1756,12 +1756,15 @@ class Channel(AbstractChannel):
                 'basic_publish: connection closed')
 
         client_properties = self.connection.client_properties
-        if client_properties['capabilities']['connection.blocked']:
-            try:
-                # Check if an event was sent, such as the out of memory message
-                self.connection.drain_events(timeout=0)
-            except socket.timeout:
-                pass
+        try:
+            if client_properties['capabilities']['connection.blocked']:
+                try:
+                    # Check if an event was sent, such as the out of memory message
+                    self.connection.drain_events(timeout=0)
+                except socket.timeout:
+                    pass
+        except KeyError:
+            pass
 
         try:
             with self.connection.transport.having_timeout(timeout):


### PR DESCRIPTION
…d return "Unrecoverable error" KeyError.  Wrapped client connection properties in try catch given we pass on socket.timout.  This is not an issue on 2.3.2.

File "/opt/fs/prodtools-ia/dev/aspera-tools-client/venv/lib/python2.7/site-packages/amqp/channel.py", line 1755, in _basic_publish
    if client_properties['capabilities']['connection.blocked']:
KeyError: u'connection.blocked'