### PR TITLE
Support float read_timeout/write_timeout

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -180,9 +180,11 @@ class _AbstractTransport(object):
         for timeout, interval in ((socket.SO_SNDTIMEO, write_timeout),
                                   (socket.SO_RCVTIMEO, read_timeout)):
             if interval is not None:
+                sec = int(interval)
+                usec = int((interval - sec) * 1000000)
                 self.sock.setsockopt(
                     socket.SOL_SOCKET, timeout,
-                    pack('ll', interval, 0),
+                    pack('ll', sec, usec),
                 )
         self._setup_transport()
 

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -218,14 +218,18 @@ class test_socket_options:
         read_timeout_sec, read_timeout_usec = 0xdead, 0xbeef
         write_timeout_sec = 0x42
 
-        self.transp.read_timeout = read_timeout_sec + read_timeout_usec * 0.000001
+        self.transp.read_timeout = read_timeout_sec + \
+            read_timeout_usec * 0.000001
         self.transp.write_timeout = write_timeout_sec
         self.transp.connect()
 
-        expected_rcvtimeo = struct.pack('ll', read_timeout_sec, read_timeout_usec)
+        expected_rcvtimeo = struct.pack('ll', read_timeout_sec,
+                                        read_timeout_usec)
         expected_sndtimeo = struct.pack('ll', write_timeout_sec, 0)
-        assert expected_rcvtimeo == self.socket.getsockopt(socket.SOL_TCP, socket.SO_RCVTIMEO)
-        assert expected_sndtimeo == self.socket.getsockopt(socket.SOL_TCP, socket.SO_SNDTIMEO)
+        assert expected_rcvtimeo == self.socket.getsockopt(socket.SOL_TCP,
+                                                           socket.SO_RCVTIMEO)
+        assert expected_sndtimeo == self.socket.getsockopt(socket.SOL_TCP,
+                                                           socket.SO_SNDTIMEO)
 
 
 class test_AbstractTransport:


### PR DESCRIPTION
I found the read_timeout/write_timeout only support integer type. If I pass 0.5 to read_timeout, the socket will block forever.