### PR TITLE
read_frame python3 compatible for large payloads

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -255,7 +255,7 @@ class _AbstractTransport(object):
             if size > SIGNED_INT_MAX:
                 part1 = read(SIGNED_INT_MAX)
                 part2 = read(size - SIGNED_INT_MAX)
-                payload = ''.join([part1, part2])
+                payload = b''.join([part1, part2])
             else:
                 payload = read(size)
             read_frame_buffer += payload


### PR DESCRIPTION
read_frame is using str.join to concatenate the payload if the received
frame is bigger than SIGNED_INT_MAX.

That's fine with python2, however in python3 documentation is stated

> str.join Return a string which is the concatenation of the strings in the
> iterable iterable. A TypeError will be raised if there are any
> non-string values in iterable, including bytes objects. The separator
> between elements is the string providing this method.

So we have to use the byte object join() method

Signed-off-by: aojeagarcia <aojeagarcia@suse.com>