### PR TITLE
Treat EWOULDBLOCK as timeout

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -112,6 +112,10 @@ class _AbstractTransport(object):
                     # Non-blocking SSL sockets can throw SSLError
                     raise socket.timeout()
                 raise
+            except socket.error as exc:
+                if get_errno(exc) == errno.EWOULDBLOCK:
+                    raise socket.timeout()
+                raise
             finally:
                 if timeout != prev:
                     sock.settimeout(prev)


### PR DESCRIPTION
py-amqp 2.4.0 caused a regression on Windows. Reading from a
non-blocking socket having the timeout set to 0 might raise a
WSAEWOULDBLOCK socket error instead of a timeout, which we're not
properly handling.

This change will make sure that we're just handling this as a
timeout, which will fix #252.