### PR TITLE
The bitcount will reset only when we move to the next byte.

### DIFF
--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -172,11 +172,10 @@ def loads(format, buf, offset=0,
             if not bitcount:
                 bits = ord(buf[offset:offset + 1])
                 offset += 1
-            bitcount = 8
+                bitcount = 8
             val = (bits & 1) == 1
             bits >>= 1
             bitcount -= 1
-
         elif p == 'o':
             bitcount = bits = 0
             val, = unpack_from('>B', buf, offset)

--- a/t/unit/test_serialization.py
+++ b/t/unit/test_serialization.py
@@ -105,6 +105,13 @@ class test_serialization:
         actual, _ = loads('BssbbbbbF', buf)
         assert actual == expected
 
+    def test_sixteen_bitflags(self):
+        expected = [True, False] * 8
+        format = 'b' * len(expected)
+        buf = dumps(format, expected)
+        actual, _ = loads(format, buf)
+        assert actual == expected
+
 
 class test_GenericContent:
 


### PR DESCRIPTION
Add a test to verify that parsing two consecutive bitmaps does not fail.