### PR TITLE
Adds Python 3.7 to Classifiers

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,10 @@ environment:
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "32"
 
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "32"
+
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
@@ -45,6 +49,11 @@ environment:
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "64"
+      WINDOWS_SDK_VERSION: "v7.1"
+
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.x"
       PYTHON_ARCH: "64"
       WINDOWS_SDK_VERSION: "v7.1"
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ classes = """
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     License :: OSI Approved :: BSD License
     Intended Audience :: Developers
     Operating System :: OS Independent


### PR DESCRIPTION
When I was researching on PyPi I noticed that Python 3.7 was missing from the list of supported language classifiers.  After digging in further I saw that Python 3.7 support was added in a previous commit.  This small PR just updates the supported languages for PyPi and the Appveyor configuration.