### PR TITLE
Use tox-docker in integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,37 +39,36 @@ matrix:
       stage: lint
     - python: 2.7
       env: MATRIX_TOXENV=integration-rabbitmq
+      services:
+        - docker
       stage: integration
     - python: 3.4
       env: MATRIX_TOXENV=integration-rabbitmq
+      services:
+        - docker
       stage: integration
     - python: 3.5
       env: MATRIX_TOXENV=integration-rabbitmq
+      services:
+        - docker
       stage: integration
     - python: 3.6
       env: MATRIX_TOXENV=integration-rabbitmq
+      services:
+        - docker
       stage: integration
     - python: 3.7
       env: MATRIX_TOXENV=integration-rabbitmq
+      services:
+        - docker
       stage: integration
 
 before_install:
     # - sudo apt install libcurl4-openssl-dev libssl-dev gnutls-dev
     - if [[ -v MATRIX_TOXENV ]]; then export TOXENV=${TRAVIS_PYTHON_VERSION}-${MATRIX_TOXENV}; fi; env
-    - |
-          if [[ "$TOXENV" == *integration* ]]; then
-              sudo echo 'deb https://dl.bintray.com/rabbitmq-erlang/debian xenial main' > /etc/apt/sources.list.d/rabbitmq-bintray.list
-              sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"
-              wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | sudo apt-key add -
-              sudo apt update
-              sudo apt install rabbitmq-server -y
-              sudo systemctl enable rabbitmq-server
-              sudo systemctl start rabbitmq-server
-          fi
-
 install:
   - pip --disable-pip-version-check install -U pip setuptools wheel | cat
-  - pip --disable-pip-version-check install -U tox | cat
+  - pip --disable-pip-version-check install -U tox tox-docker | cat
 script: tox -v -- -v
 after_success:
   - .tox/$TRAVIS_PYTHON_VERSION/bin/coverage xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,16 @@ matrix:
       services:
         - docker
       stage: integration
+    - python: pypy2.7-6.0
+      env: MATRIX_TOXENV=integration-rabbitmq
+      services:
+        - docker
+      stage: integration
+    - python: pypy3.5-6.0
+      env: MATRIX_TOXENV=integration-rabbitmq
+      services:
+        - docker
+      stage: integration
 
 before_install:
     # - sudo apt install libcurl4-openssl-dev libssl-dev gnutls-dev

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,3 +1,4 @@
 pytest-cov
 codecov
 pytest-travis-fold
+pytest-xdist

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,7 @@ sitepackages = False
 recreate = False
 commands =
     unit: py.test -xv --cov=amqp --cov-report=xml --no-cov-on-fail t/unit
-    integration: py.test -xv -E rabbitmq t/integration
-
+    integration: py.test -xv -E rabbitmq t/integration {posargs:-n2}
 basepython =
     2.7,flakeplus,flake8,apicheck,linkcheck,pydocstyle: python2.7
     pypy2.7-6.0,pypy3.5-6.0: pypy
@@ -29,6 +28,11 @@ basepython =
     3.6: python3.6
     3.7: python3.7
 install_command = python -m pip --disable-pip-version-check install {opts} {packages}
+commands_pre =
+    integration-rabbitmq: ./wait_for_rabbitmq.sh
+docker =
+    integration-rabbitmq: rabbitmq:alpine
+dockerenv = PYAMQP_INTEGRATION_INSTANCE=1
 
 [testenv:apicheck]
 commands =

--- a/wait_for_rabbitmq.sh
+++ b/wait_for_rabbitmq.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+containers=$(sudo docker ps -q | tail -n +1)
+
+for item in ${containers//\\n/}
+do
+  env=$(sudo docker inspect -f '{{range $index, $value := .Config.Env}}{{$value}} {{end}}' $item);
+  if [[ $env == *"PYAMQP_INTEGRATION_INSTANCE=1"* ]]; then
+    grep -m1 'Server startup complete' <(sudo docker logs -f $item)
+    sudo docker exec $item rabbitmqctl add_vhost gw0
+    sudo docker exec $item rabbitmqctl set_permissions -p gw0 guest ".*" ".*" ".*"
+    sudo docker exec $item rabbitmqctl add_vhost gw1
+    sudo docker exec $item rabbitmqctl set_permissions -p gw1 guest ".*" ".*" ".*"
+  fi
+done;


### PR DESCRIPTION
Instead of installing RabbitMQ from apt we now use Docker.
This will allow us to test multiple RabbitMQ versions more easily.

I also added more test coverage to our integration suite.