### PR TITLE
Provide fix for #242, Option not supported by protocol on SunOS

### DIFF
--- a/amqp/platform.py
+++ b/amqp/platform.py
@@ -62,8 +62,8 @@ elif sys.platform.startswith('win'):
 elif sys.platform.startswith('cygwin'):
     KNOWN_TCP_OPTS = {'TCP_NODELAY'}
 
-# illumos do not allow to set the TCP_MAXSEG, also if the Oracle documentation
-# provides other information.
+# illumos does not allow to set the TCP_MAXSEG socket option,
+# even if the Oracle documentation says otherwise.
 elif sys.platform.startswith('sunos'):
     KNOWN_TCP_OPTS.remove('TCP_MAXSEG')
 

--- a/amqp/platform.py
+++ b/amqp/platform.py
@@ -62,6 +62,11 @@ elif sys.platform.startswith('win'):
 elif sys.platform.startswith('cygwin'):
     KNOWN_TCP_OPTS = {'TCP_NODELAY'}
 
+# illumos do not allow to set the TCP_MAXSEG, also if the Oracle documentation
+# provides other information.
+elif sys.platform.startswith('sunos'):
+    KNOWN_TCP_OPTS.remove('TCP_MAXSEG')
+
 if sys.version_info < (2, 7, 7):  # pragma: no cover
     import functools
 


### PR DESCRIPTION
It is not possible to set TCP_MAXSEG on illumos based distributions, which includes OmniOSce, SmartOS, OpenIndiana and more. The Oracle documentation provides information that the option could be set, but this isn't true based on the illumos source code: https://github.com/illumos/illumos-gate/blob/master/usr/src/uts/common/inet/tcp/tcp_opt_data.c#L93-L94

Removing this option for SunOS should be no problem, because the code would anyway set the same default value which is provided by the socket.

Fixes #242.