### PR TITLE
Fix faulty ssl sni intiation parameters

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -317,7 +317,7 @@ class SSLTransport(_AbstractTransport):
 
     def _wrap_socket_sni(self, sock, keyfile=None, certfile=None,
                          server_side=False, cert_reqs=ssl.CERT_NONE,
-                         ca_certs=None, do_handshake_on_connect=True,
+                         ca_certs=None, do_handshake_on_connect=False,
                          suppress_ragged_eofs=True, server_hostname=None,
                          ciphers=None, ssl_version=None):
         """Socket wrap with SNI headers.
@@ -357,8 +357,10 @@ class SSLTransport(_AbstractTransport):
                 hasattr(ssl, 'SSLContext')):
             context = ssl.SSLContext(opts['ssl_version'])
             context.verify_mode = cert_reqs
-            context.check_hostname = True
-            context.load_cert_chain(certfile, keyfile)
+            if cert_reqs != ssl.CERT_NONE:
+                context.check_hostname = True
+            if (certfile is not None) and (keyfile is not None):
+                context.load_cert_chain(certfile, keyfile)
             sock = context.wrap_socket(sock, server_hostname=server_hostname)
         return sock
 

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -631,7 +631,7 @@ class test_SSLTransport:
                                              ca_certs=None, server_side=False,
                                              ciphers=None, ssl_version=2,
                                              suppress_ragged_eofs=True,
-                                             do_handshake_on_connect=True)
+                                             do_handshake_on_connect=False)
 
     def test_shutdown_transport(self):
         self.t.sock = None


### PR DESCRIPTION
We need to have 'do_handshake_on_connect' default to false due to the faulty code that executes before the sni options can be applied.

Also 
 context.check_hostname should not default to true this is a faulty default
 certfile,keyfile need to be non null before context.load_cert_chain(certfile, keyfile)