### PR TITLE
Fix a channel issue against a connection already closed

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -510,9 +510,11 @@ class Connection(AbstractChannel):
         return self.on_inbound_frame(frame)
 
     def on_inbound_method(self, channel_id, method_sig, payload, content):
-        return self.channels[channel_id].dispatch_method(
-            method_sig, payload, content,
-        )
+        if self.channels is not None:
+            return self.channels[channel_id].dispatch_method(
+                method_sig, payload, content,
+            )
+        raise RecoverableConnectionError('Connection already closed')
 
     def close(self, reply_code=0, reply_text='', method_sig=(0, 0),
               argsig='BsBB'):


### PR DESCRIPTION
In some possible case a connection can be closed (network issue, etc...) and
then channels reset to None, in this case if the client use
the `on_inbound_method` then we can facing a TypeError exception.

The `on_inbound_method` is not enough safer and then this method can
try to get channel from a none existing object.

In this case we need to raise a `RecoverableConnectionError` to allow client
to re-connect properly and re-init objects properly.