### PR TITLE
Fix pypi classifier development status

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ NAME = 'amqp'
 # -*- Classifiers -*-
 
 classes = """
-    Development Status :: 5 - Production/Stable
+    Development Status :: 2 - Pre-Alpha
     Programming Language :: Python
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7


### PR DESCRIPTION
The version 5.0 is currently an alpha version
but pypi classifiers tag this version as a production/stable version,
this is wrong, this version is a pre-alpha version.

The main issue is that by using pip or requirements file to install
py-amqp it will pull and install the pre-alpha version (5.0) instead of
the stable version 2.5.2.

Normally pip don't install non stable version except if user
explicitly specify to install a non stable version.

Example with oslo.messaging:

```
$ pip install oslo.messaging
```

The previous command will pull py-amqp 5.0