### PR TITLE
upgrade tox-docker and force rabbitmq to listen on port 5671

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ before_install:
     - if [[ -v MATRIX_TOXENV ]]; then export TOXENV=${TRAVIS_PYTHON_VERSION}-${MATRIX_TOXENV}; fi; env
 install:
   - pip --disable-pip-version-check install -U pip setuptools wheel | cat
-  - pip --disable-pip-version-check install -U --upgrade-strategy eager tox "tox-docker==1.2.1" | cat
+  - pip --disable-pip-version-check install -U --upgrade-strategy eager tox tox-docker | cat
 script: tox -v -- -v
 after_success:
   - .tox/$TRAVIS_PYTHON_VERSION/bin/coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,9 @@ commands_pre =
     integration-rabbitmq: ./wait_for_rabbitmq.sh
 docker =
     integration-rabbitmq: rabbitmq:alpine
-dockerenv = PYAMQP_INTEGRATION_INSTANCE=1
+dockerenv = 
+    PYAMQP_INTEGRATION_INSTANCE=1
+    RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit tcp_listeners [5671,5672]
 
 [testenv:apicheck]
 commands =


### PR DESCRIPTION
Workaround for https://github.com/tox-dev/tox-docker/issues/39

Wasted an afternoon with that so I figure I would pass around the result