### PR TITLE
Cython generic content

### DIFF
--- a/amqp/basic_message.pxd
+++ b/amqp/basic_message.pxd
@@ -1,0 +1,5 @@
+from serialization cimport GenericContent
+
+cdef class Message(GenericContent):
+    cdef public object channel
+    cdef public object delivery_info

--- a/amqp/method_framing.pxd
+++ b/amqp/method_framing.pxd
@@ -1,0 +1,1 @@
+from basic_message cimport Message

--- a/amqp/method_framing.pxd
+++ b/amqp/method_framing.pxd
@@ -1,1 +1,4 @@
 from basic_message cimport Message
+
+cdef object FRAME_OVERHEAD
+cdef object _CONTENT_METHODS

--- a/amqp/serialization.pxd
+++ b/amqp/serialization.pxd
@@ -23,3 +23,19 @@ cdef int _write_array(l, write, bits) except -1
 cdef tuple decode_properties_basic(buf, int offset)
 
 cdef int _write_item(v, write, bits) except -1
+
+
+cdef class GenericContent:
+    cdef public object frame_method
+    cdef public object frame_args
+    cdef public object body
+    cdef public list _pending_chunks
+    cdef public int body_received
+    cdef public int body_size
+    cdef public bint ready
+    cdef public dict properties
+
+    @cython.locals(shift=cython.int, flag_bits=cython.int, flags=list)
+    cpdef bytes _serialize_properties(self)
+
+    cpdef int _load_properties(self, class_id, buf, offset)

--- a/amqp/serialization.pxd
+++ b/amqp/serialization.pxd
@@ -24,6 +24,7 @@ cdef tuple decode_properties_basic(buf, int offset)
 
 cdef int _write_item(v, write, bits) except -1
 
+cdef dict PROPERTY_CLASSES
 
 cdef class GenericContent:
     cdef public object frame_method

--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -479,11 +479,6 @@ class GenericContent(object):
     CLASS_ID = None
     PROPERTIES = [('dummy', 's')]
 
-    __slots__ = (
-        'frame_method', 'frame_args', '_pending_chunks', 'body',
-        'body_received', 'body_size', 'ready', 'properties'
-    )
-
     def __init__(self, frame_method=None, frame_args=None, **props):
         self.frame_method = frame_method
         self.frame_args = frame_args

--- a/t/unit/test_serialization.py
+++ b/t/unit/test_serialization.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from datetime import datetime
 from decimal import Decimal
 from math import ceil
+import pickle
 
 import pytest
 
@@ -140,11 +141,12 @@ class test_GenericContent:
 
     def test_getattr(self):
         self.g.properties['foo'] = 30
-        with pytest.raises(AttributeError):
-            self.g.__setstate__
         assert self.g.foo == 30
         with pytest.raises(AttributeError):
             self.g.bar
+
+    def test_pickle(self):
+        pickle.loads(pickle.dumps(self.g))
 
     def test_load_properties(self):
         m = Message()


### PR DESCRIPTION
This PR enhances speedups by cythonizing classes `amqp.Message` and `amqp.GenericContent`. The main purpose of this PR is to optimize creation of mentioned classes since they are created *each* message coming from Broker.

1. No optimization - pure python
```
python -m timeit -s 'import amqp' "amqp.Message(body='Hello world', content_type='text/plain', application_content={'bar': 7, 'foo':5, 'list': [1,2,3]}, priority=5, correlation_id='correlation_id', reply_to='reply-to', expiration='expiration_value', message_id='message_id_value', timestamp=1234567890, type='type_value', user_id='user_id_value', app_id='app_id_value', cluster_id='cluster_id_value')._serialize_properties()"
10000 loops, best of 5: 35.5 usec per loop
```

2. With speedups before patch
```
python -m timeit -s 'import amqp' "amqp.Message(body='Hello world', content_type='text/plain', application_content={'bar': 7, 'foo':5, 'list': [1,2,3]}, priority=5, correlation_id='correlation_id', reply_to='reply-to', expiration='expiration_value', message_id='message_id_value', timestamp=1234567890, type='type_value', user_id='user_id_value', app_id='app_id_value', cluster_id='cluster_id_value')._serialize_properties()"
10000 loops, best of 5: 20.1 usec per loop
```

3. With speedups after patch
```
python -m timeit -s 'import amqp' "amqp.Message(body='Hello world', content_type='text/plain', application_content={'bar': 7, 'foo':5, 'list': [1,2,3]}, priority=5, correlation_id='correlation_id', reply_to='reply-to', expiration='expiration_value', message_id='message_id_value', timestamp=1234567890, type='type_value', user_id='user_id_value', app_id='app_id_value', cluster_id='cluster_id_value')._serialize_properties()"
20000 loops, best of 5: 17.6 usec per loop
```

**Compatiblity note:** pickled `amqp.Message` object is not portable between cythonized and pure python version of library. In other words, one cannot unpickle `amqp.Message` object in cythonized library if it was pickled in pure python library.