### PR TITLE
Small improvements of speedups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
     PYTHONUNBUFFERED=yes
   matrix:
     - MATRIX_TOXENV=unit
-    - MATRIX_TOXENV=unit CELERY_ENABLE_SPEEDUPS=1
 
 stages:
   - test
@@ -24,21 +23,15 @@ stages:
   - lint
 
 _integration_job: &integration_job
-  script:
-      - docker build -t rabbitmq:tls .
-      - tox -v -- -v
-  services:
-    - docker
-  stage: integration
-  env: MATRIX_TOXENV=integration-rabbitmq
+    script:
+        - docker build -t rabbitmq:tls .
+        - tox -v -- -v
+    services:
+      - docker
+    stage: integration
 
 matrix:
   fast_finish: true
-  exclude:
-    - python: pypy2.7-6.0
-      env: MATRIX_TOXENV=unit CELERY_ENABLE_SPEEDUPS=1
-    - python: pypy3.5-6.0
-      env: MATRIX_TOXENV=unit CELERY_ENABLE_SPEEDUPS=1
   include:
     - python: 2.7
       env: TOXENV=flake8
@@ -54,18 +47,41 @@ matrix:
       stage: lint
     - python: 2.7
       <<: *integration_job
+      env: MATRIX_TOXENV=integration-rabbitmq
     - python: 3.5
       <<: *integration_job
+      env: MATRIX_TOXENV=integration-rabbitmq
     - python: 3.6
       <<: *integration_job
+      env: MATRIX_TOXENV=integration-rabbitmq
     - python: 3.7
       <<: *integration_job
+      env: MATRIX_TOXENV=integration-rabbitmq
     - python: 3.8
       <<: *integration_job
+      env: MATRIX_TOXENV=integration-rabbitmq
     - python: pypy2.7-6.0
       <<: *integration_job
+      env: MATRIX_TOXENV=integration-rabbitmq
     - python: pypy3.5-6.0
       <<: *integration_job
+      env: MATRIX_TOXENV=integration-rabbitmq
+    - python: 2.7
+      <<: *integration_job
+      env: MATRIX_TOXENV=integration-rabbitmq CELERY_ENABLE_SPEEDUPS=1
+    - python: 3.5
+      <<: *integration_job
+      env: MATRIX_TOXENV=integration-rabbitmq CELERY_ENABLE_SPEEDUPS=1
+    - python: 3.6
+      <<: *integration_job
+      env: MATRIX_TOXENV=integration-rabbitmq CELERY_ENABLE_SPEEDUPS=1
+    - python: 3.7
+      <<: *integration_job
+      env: MATRIX_TOXENV=integration-rabbitmq CELERY_ENABLE_SPEEDUPS=1
+    - python: 3.8
+      <<: *integration_job
+      env: MATRIX_TOXENV=integration-rabbitmq CELERY_ENABLE_SPEEDUPS=1
+
 
 before_install:
     - if [[ -v MATRIX_TOXENV ]]; then export TOXENV=${TRAVIS_PYTHON_VERSION}-${MATRIX_TOXENV}; fi; env

--- a/amqp/abstract_channel.pxd
+++ b/amqp/abstract_channel.pxd
@@ -1,0 +1,6 @@
+import cython
+from .serialization cimport loads, dumps
+
+cdef object AMQP_LOGGER
+cdef object IGNORED_METHOD_DURING_CHANNEL_CLOSE
+

--- a/amqp/serialization.pxd
+++ b/amqp/serialization.pxd
@@ -30,7 +30,7 @@ cdef class GenericContent:
     cdef public object frame_method
     cdef public object frame_args
     cdef public object body
-    cdef public list _pending_chunks
+    cdef list _pending_chunks
     cdef public int body_received
     cdef public int body_size
     cdef public bint ready
@@ -39,4 +39,4 @@ cdef class GenericContent:
     @cython.locals(shift=cython.int, flag_bits=cython.int, flags=list)
     cpdef bytes _serialize_properties(self)
 
-    cpdef int _load_properties(self, class_id, buf, offset)
+    cdef int _load_properties(self, class_id, buf, offset)

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,10 @@ if os.environ.get("CELERY_ENABLE_SPEEDUPS"):
             'amqp.method_framing',
             ["amqp/method_framing.py"],
         ),
+        setuptools.Extension(
+            'amqp.abstract_channel',
+            ["amqp/abstract_channel.py"],
+        ),
     ]
 else:
     setup_requires = []


### PR DESCRIPTION
This PR:
1. Add trivial speedup for abstract_channels.py. The main benefit is to call `load()`/`dumps()`  functions on C level instead of using slow python function invocation
2. CI executes speedup tests on integration level instead of unittest level. This allows to use more aggresive cythonization of code
3. Cythonize more aggressively `GenericContent()` class