### PR TITLE
Fix saving partial read buffer on windows during socket timeout.

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2009 Barry Pederson <bp@barryp.org>
 from __future__ import absolute_import, unicode_literals
 
+import os
 import errno
 import re
 import socket
@@ -256,7 +257,15 @@ class _AbstractTransport(object):
             # so we know the size can be at most 2 * SIGNED_INT_MAX
             if size > SIGNED_INT_MAX:
                 part1 = read(SIGNED_INT_MAX)
-                part2 = read(size - SIGNED_INT_MAX)
+
+                # In case this read times out, we need to make sure to not
+                # lose part1 when we retry the read
+                try:
+                    part2 = read(size - SIGNED_INT_MAX)
+                except:
+                    read_frame_buffer += part1
+                    raise
+
                 payload = b''.join([part1, part2])
             else:
                 payload = read(size)
@@ -266,10 +275,19 @@ class _AbstractTransport(object):
             self._read_buffer = read_frame_buffer + self._read_buffer
             raise
         except (OSError, IOError, SSLError, socket.error) as exc:
-            # Don't disconnect for ssl read time outs
-            # http://bugs.python.org/issue10272
-            if isinstance(exc, SSLError) and 'timed out' in str(exc):
+            # 1. Don't disconnect for ssl read time outs
+            #    http://bugs.python.org/issue10272
+            # 2. On windows we can get a read timeout with a winsock error
+            #    code instead of a proper socket.timeout() error, see
+            #    https://github.com/celery/py-amqp/issues/320
+            # These cases should be handled as if they were socket.timeout
+            # errors.
+            if ((isinstance(exc, socket.error) and os.name == 'nt'
+                 and get_errno(exc) == errno.EWOULDBLOCK) or
+                (isinstance(exc, SSLError) and 'timed out' in str(exc))):
+                self._read_buffer = read_frame_buffer + self._read_buffer
                 raise socket.timeout()
+
             if get_errno(exc) not in _UNAVAIL:
                 self.connected = False
             raise

--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -262,7 +262,7 @@ class _AbstractTransport(object):
                 # lose part1 when we retry the read
                 try:
                     part2 = read(size - SIGNED_INT_MAX)
-                except:
+                except:  # noqa
                     read_frame_buffer += part1
                     raise
 
@@ -282,9 +282,14 @@ class _AbstractTransport(object):
             #    https://github.com/celery/py-amqp/issues/320
             # These cases should be handled as if they were socket.timeout
             # errors.
-            if ((isinstance(exc, socket.error) and os.name == 'nt'
-                 and get_errno(exc) == errno.EWOULDBLOCK) or
-                (isinstance(exc, SSLError) and 'timed out' in str(exc))):
+            if (
+                isinstance(exc, socket.error) and os.name == 'nt'
+                and get_errno(exc) == errno.EWOULDBLOCK  # noqa
+            ):
+                self._read_buffer = read_frame_buffer + self._read_buffer
+                raise socket.timeout()
+
+            if isinstance(exc, SSLError) and 'timed out' in str(exc):
                 self._read_buffer = read_frame_buffer + self._read_buffer
                 raise socket.timeout()
 

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -727,9 +727,10 @@ class test_TCPTransport:
 
         self.t._quick_recv.side_effect = [
             pack('>BHI', 1, 1, 16),
-            BlockingIOError(
+            socket.error(
                 10035,
-                "A non-blocking socket operation could not be completed immediately"
+                "A non-blocking socket operation could "
+                "not be completed immediately"
             ),
             b'thequickbrownfox',
             b'\xce'


### PR DESCRIPTION
Fixes Issue #320.

When a frame read times out on Windows, the error raised did not trigger the transport logic to save off the initial partial read so that a future call to `read_frame()` would reread the partially read data.  This caused framing errors in certain cases on Windows.

Also fixes a similar error that could occur on any platform during reads on `len(payload) > SIGNED_INT_MAX`, where reading the payload is not an atomic read but split into two reads.  If the first succeeded but the second failed, the contents of the first read would be thrown away causing framing errors on subsequent calls to `read_frame`.