### PR TITLE
Fix deserialization of long string field values that are not utf-8.

### DIFF
--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -42,7 +42,11 @@ def _read_item(buf, offset):
     if ftype == 'S':
         slen, = unpack_from('>I', buf, offset)
         offset += 4
-        val = pstr_t(buf[offset:offset + slen])
+        try:
+            val = pstr_t(buf[offset:offset + slen])
+        except UnicodeDecodeError:
+            val = buf[offset:offset + slen]
+
         offset += slen
     # 's': short string
     elif ftype == 's':

--- a/t/unit/test_serialization.py
+++ b/t/unit/test_serialization.py
@@ -26,6 +26,7 @@ class test_serialization:
 
     @pytest.mark.parametrize('descr,frame,expected,cast', [
         ('S', b's8thequick', 'thequick', None),
+        ('S', b'S\x00\x00\x00\x03\xc0\xc0\x00', b'\xc0\xc0\x00', None),
         ('x', b'x\x00\x00\x00\x09thequick\xffIGNORED', b'thequick\xff', None),
         ('b', b'b' + pack('>B', True), True, None),
         ('B', b'B' + pack('>b', 123), 123, None),


### PR DESCRIPTION
AMQP 0.9.1 allows arbitrary data in long string fields.  However, py-amqp assumed that the fields would always contain valid utf-8 data and would fail to deserialize messages with a property that contained non-utf-8 data.

See #323 

I'm open to adjusting the fix if there's a better way to handle this, please just let me know what the desired resolution is if not this simple one.