### PR TITLE
Stop to use deprecated method ssl.wrap_socket

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -94,8 +94,8 @@ class Connection(AbstractChannel):
     client name. For EXTERNAL authentication both userid and password are
     ignored.
 
-    The 'ssl' parameter may be simply True/False, or for Python >= 2.6
-    a dictionary of options to pass to ssl.wrap_socket() such as
+    The 'ssl' parameter may be simply True/False, or for Python >= 3.6
+    a dictionary of options to pass to ssl.SSLContext such as
     requiring certain certificates.
 
     The "socket_settings" parameter is a dictionary defining tcp

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -1,7 +1,6 @@
 import errno
 import os
 import socket
-import ssl
 import struct
 from struct import pack
 from unittest.mock import ANY, MagicMock, Mock, call, patch
@@ -616,18 +615,13 @@ class test_SSLTransport:
 
     def test_wrap_socket_sni(self):
         sock = Mock()
-        with patch('ssl.wrap_socket') as mock_ssl_wrap:
+        with patch('ssl.SSLContext.wrap_socket') as mock_ssl_wrap:
             self.t._wrap_socket_sni(sock)
-            mock_ssl_wrap.assert_called_with(cert_reqs=0,
-                                             certfile=None,
-                                             keyfile=None,
-                                             sock=sock,
-                                             ca_certs=None,
+            mock_ssl_wrap.assert_called_with(sock=sock,
                                              server_side=False,
-                                             ciphers=None,
-                                             ssl_version=ssl.PROTOCOL_TLS,
+                                             do_handshake_on_connect=False,
                                              suppress_ragged_eofs=True,
-                                             do_handshake_on_connect=False)
+                                             server_hostname=None)
 
     def test_shutdown_transport(self):
         self.t.sock = None


### PR DESCRIPTION
`ssl.wrap_socket` is deprecated since python 3.7 and since python 3.2
and 2.7.9 (released in 2014) it is recommended to use the
SSLContext.wrap_socket() instead of wrap_socket(). The top-level
function is limited and creates an insecure client socket without server
name indication or hostname matching [1].

Python 2.7 is now officially unmaintained, latest version of
python 2.7 is 2.7.18, py-amqp only support python versions who are compatible
with these changes [2].

These changes move away from `ssl.wrap_socket` by using
now `ssl.SSLContext.wrap_socket` [3].

Will close #303 

[1] https://docs.python.org/3/library/ssl.html#ssl.wrap_socket
[2] https://github.com/celery/py-amqp/blob/master/setup.py#L24,L29
[3] https://docs.python.org/3/library/ssl.html#ssl.SSLContext.wrap_socket