### PR TITLE
Multiple improvements of cythonized code

### DIFF
--- a/amqp/abstract_channel.pxd
+++ b/amqp/abstract_channel.pxd
@@ -1,3 +1,4 @@
+# cython: language_level=3
 import cython
 from .serialization cimport loads, dumps
 

--- a/amqp/basic_message.pxd
+++ b/amqp/basic_message.pxd
@@ -1,4 +1,5 @@
-from serialization cimport GenericContent
+# cython: language_level=3
+from .serialization cimport GenericContent
 
 cdef class Message(GenericContent):
     cdef public object channel

--- a/amqp/method_framing.pxd
+++ b/amqp/method_framing.pxd
@@ -1,4 +1,9 @@
-from basic_message cimport Message
+# cython: language_level=3
+from .basic_message cimport Message
 
 cdef object FRAME_OVERHEAD
 cdef object _CONTENT_METHODS
+
+cdef class Buffer:
+    cdef bytearray _buf
+    cdef object view

--- a/amqp/serialization.pxd
+++ b/amqp/serialization.pxd
@@ -1,4 +1,8 @@
+# cython: language_level=3
 import cython
+
+from amqp.utils cimport str_to_bytes
+from amqp.utils cimport bytes_to_str as pstr_t
 
 cdef int _flushbits(list bits, write)
 

--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -16,8 +16,6 @@ from .spec import Basic
 from .utils import bytes_to_str as pstr_t
 from .utils import str_to_bytes
 
-ftype_t = chr
-
 ILLEGAL_TABLE_TYPE = """\
     Table type {0!r} not handled by amqp.
 """
@@ -32,7 +30,7 @@ ILLEGAL_TABLE_TYPE_WITH_VALUE = """\
 
 
 def _read_item(buf, offset):
-    ftype = ftype_t(buf[offset])
+    ftype = chr(buf[offset])
     offset += 1
 
     # 'S': long string

--- a/amqp/utils.pxd
+++ b/amqp/utils.pxd
@@ -1,0 +1,4 @@
+# cython: language_level=3
+
+cpdef str_to_bytes(s)
+cpdef bytes_to_str(s)

--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,10 @@ if os.environ.get("CELERY_ENABLE_SPEEDUPS"):
             'amqp.abstract_channel',
             ["amqp/abstract_channel.py"],
         ),
+        setuptools.Extension(
+            'amqp.utils',
+            ["amqp/utils.py"],
+        ),
     ]
 else:
     setup_requires = []


### PR DESCRIPTION
* set cython language_level = 3
* Cythonize amqp.method_framing.Buffer
* Use directly chr() function
* Cythonize str_to_bytes() and bytes_to_str() in amqp/utils.py