### PR TITLE
Map in Docker only used 5671 and 5672 ports

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,9 @@ dockerenv =
     RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit tcp_listeners [5672]
 
 [docker:rabbitmq:tls]
+ports =
+    5672:5672/tcp
+    5671:5671/tcp
 healthcheck_cmd = /bin/bash -c 'rabbitmq-diagnostics ping -q'
 healthcheck_interval = 10
 healthcheck_timeout = 10


### PR DESCRIPTION
Latest builds are failing with the following error:
```
Exception: Never got answer on port 15691/tcp from rabbitmq
```
It seems that explicit mapping of ports 5671 and 5672 fixes this issue. Moreover, only these two ports are used in tests.