### PR TITLE
Fix CI appveyor/tox error

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     flakeplus
     apicheck
     pydocstyle
-requires = tox-docker
+requires = tox-docker>=2.0
 
 [testenv]
 deps=
@@ -31,12 +31,13 @@ install_command = python -m pip --disable-pip-version-check install {opts} {pack
 commands_pre =
     integration-rabbitmq: ./wait_for_rabbitmq.sh
 docker =
-    integration-rabbitmq: rabbitmq:tls
+    integration-rabbitmq: rabbitmq
 dockerenv =
     PYAMQP_INTEGRATION_INSTANCE=1
     RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbit tcp_listeners [5672]
 
-[docker:rabbitmq:tls]
+[docker:rabbitmq]
+image = rabbitmq
 ports =
     5672:5672/tcp
     5671:5671/tcp


### PR DESCRIPTION
tox-docker 2.0.0 was released and is backward incompatible.

Fix the tox ini section.