### PR TITLE
Pass long_description to setup()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import codecs
 import re
 import sys
 from os import environ


### PR DESCRIPTION
Also gets rid of ugly `os.path` usage.

After my changes, we always use `here` as a reference point instead of using relative paths. Before, the code used

- `'./README.rst'` (in an uncalled function)
- `os.path.join(os.cwd(), p)` (which is the same as just using `p` directly)
- `os.path.join(here, p)` (which is relative to the directory `setup.py` is in)

Untested, please check before merging