### PR TITLE
reduce memory usage of Connection

### DIFF
--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -150,7 +150,7 @@ class Channel(AbstractChannel):
         connection, self.connection = self.connection, None
         if connection:
             connection.channels.pop(channel_id, None)
-            connection._avail_channel_ids.append(channel_id)
+            connection._used_channel_ids.remove(channel_id)
         self.callbacks.clear()
         self.cancel_callbacks.clear()
         self.events.clear()

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -1,6 +1,7 @@
 import re
 import socket
 import warnings
+from array import array
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -347,8 +348,11 @@ class test_Connection:
         self.conn.collect()
         self.conn.collect()
 
+    def test_get_free_channel_id(self):
+        assert self.conn._get_free_channel_id() == 1
+
     def test_get_free_channel_id__raises_IndexError(self):
-        self.conn._avail_channel_ids = []
+        self.conn._used_channel_ids = array('H', range(1, self.conn.channel_max))
         with pytest.raises(ResourceError):
             self.conn._get_free_channel_id()
 


### PR DESCRIPTION
While looking into https://github.com/celery/celery/issues/4843#issuecomment-991394349, I noticed [Connection._avail_channel_ids](https://github.com/celery/py-amqp/blob/v5.0.7/amqp/connection.py#L270) seems to be the thing that uses the most memory on a `Connection`:
<img src="https://user-images.githubusercontent.com/5026795/145656621-d1511790-c548-4b1a-be27-61b9cbcd5585.png" height="280">

Currently `_avail_channel_ids` is defined on `Connection` like this:
```
self._avail_channel_ids = array('H', range(self.channel_max, 0, -1))
```

It creates an array of all possible channel ids and removes them as they're used.

This PR reduces the memory usage of the `Connection` by reversing that logic and turning `_avail_channel_ids` into `_used_channel_ids`. This will only store the channel ids that are currently used, which is almost always going to be a much smaller array.

You can see the empty arrays use a lot less memory:
```
>>> from array import array
>>> import sys
>>> sys.getsizeof(array('H'))
64
>>> sys.getsizeof(array('H', range(65535, 0, -1)))
133524
```

There's downside though: It's going to take a little bit longer to `_get_free_channel_id`, because it's now going to start counting from the 1 to channel_max and return the first number that doesn't exist in `_used_channel_ids`.

However, this could potentially reduce the severity of memory leaks.