### PR TITLE
Add additional error handling for failed connections.

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -272,7 +272,11 @@ class _AbstractTransport:
 
     def close(self):
         if self.sock is not None:
-            self._shutdown_transport()
+            try:
+                self._shutdown_transport()
+            except OSError:
+                pass
+
             # Call shutdown first to make sure that pending messages
             # reach the AMQP broker if the program exits after
             # calling this method.
@@ -280,7 +284,11 @@ class _AbstractTransport:
                 self.sock.shutdown(socket.SHUT_RDWR)
             except OSError:
                 pass
-            self.sock.close()
+
+            try:
+                self.sock.close()
+            except OSError:
+                pass
             self.sock = None
         self.connected = False
 

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -835,6 +835,23 @@ class test_SSLTransport:
         self.t._shutdown_transport()
         assert self.t.sock is sock.unwrap()
 
+    def test_close__unwrap_error(self):
+        # sock.unwrap() can raise an error if the was a connection failure
+        # make sure the socket is properly closed and deallocated
+        sock = self.t.sock = Mock()
+        sock.unwrap.side_effect = OSError
+        self.t.close()
+        assert self.t.sock is None
+
+    def test_close__close_error(self):
+        # sock.close() can raise an error if the fd is invalid
+        # make sure the socket is properly deallocated
+        sock = self.t.sock = Mock()
+        sock.close.side_effect = OSError
+        self.t.close()
+        sock.close.assert_called_with()
+        assert self.t.sock is None and self.t.connected is False
+
     def test_read_EOF(self):
         self.t.sock = Mock(name='SSLSocket')
         self.t.connected = True


### PR DESCRIPTION
Fixes #378

The previous PR #374 removed a blanket ``try...except OSError`` that was preventing sockets from being deallocated because ``self.sock.close()`` was never being reached.

As a side effect, it was discovered in that OSError might also be raised for TLS connections inside of ``self._shutdown_transport()``. Rather than revert the previous change, this PR adds extra error handling so that SSL sockets that fail to unwrap because of a connection failure will still be appropriately closed. 