### PR TITLE
Fix CHANNEL_ERROR/ChannelNotOpen

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -484,6 +484,7 @@ class Connection(AbstractChannel):
     def _get_free_channel_id(self):
         for channel_id in range(1, self.channel_max):
             if channel_id not in self._used_channel_ids:
+                self._used_channel_ids.append(channel_id)
                 return channel_id
 
         raise ResourceError(

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -350,6 +350,7 @@ class test_Connection:
 
     def test_get_free_channel_id(self):
         assert self.conn._get_free_channel_id() == 1
+        assert self.conn._get_free_channel_id() == 2
 
     def test_get_free_channel_id__raises_IndexError(self):
         self.conn._used_channel_ids = array('H', range(1, self.conn.channel_max))


### PR DESCRIPTION
Fixes: #382

This is related to an issue caused by #377.

Before the change in #377, `_get_free_channel_id` was modifying the array of available channels. After the change, the array was no longer being modified to track the newly used channel. This caused the issue in #382 where it attempts to open the channel twice.

This PR fixes the issue by appending to the array of currently used channels when `_get_free_channel_id` is used.