### PR TITLE
document memoryview usage, minor frame_writer.write_frame refactor 

### DIFF
--- a/t/integration/test_integration.py
+++ b/t/integration/test_integration.py
@@ -415,6 +415,17 @@ class test_connection:
                 )
                 callback_mock.assert_called_once_with()
 
+    def test_send_heartbeat(self):
+        """The send_heartbeat method writes the expected output."""
+        conn = Connection()
+        with patch.object(conn, 'Transport') as transport_mock:
+            handshake(conn, transport_mock)
+            transport_mock().write.reset_mock()
+            conn.send_heartbeat()
+            transport_mock().write.assert_called_once_with(
+                memoryview(bytearray(b'\x08\x00\x00\x00\x00\x00\x00\xce'))
+            )
+
 
 class test_channel:
     # Integration tests. Tests verify the correctness of communication between


### PR DESCRIPTION
I was looking at more py-amqp code and found a really interesting usage of `memoryview` in `frame_writer`'s `buffer_store`. I added some comments explaining why it's used.

I also moved some variables in `frame_writer`'s `write_frame` closer to where they're actually used. The `buffer_store` isn't used by `write_frame` when it ends up in the `if bigbody:` block, so I moved the code related to the `buffer_store` into the `else:`.