### PR TITLE
improve performance of _get_free_channel_id, fix channel max bug

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -482,8 +482,11 @@ class Connection(AbstractChannel):
         self._transport = self.connection = self.channels = None
 
     def _get_free_channel_id(self):
-        for channel_id in range(1, self.channel_max):
-            if channel_id not in self._used_channel_ids:
+        # Cast to a set for fast lookups, and keep stored as an array for lower memory usage.
+        used_channel_ids = set(self._used_channel_ids)
+
+        for channel_id in range(1, self.channel_max + 1):
+            if channel_id not in used_channel_ids:
                 self._used_channel_ids.append(channel_id)
                 return channel_id
 

--- a/t/integration/test_integration.py
+++ b/t/integration/test_integration.py
@@ -1,4 +1,5 @@
 import socket
+from array import array
 from struct import pack
 from unittest.mock import ANY, Mock, call, patch
 
@@ -534,9 +535,11 @@ class test_channel:
             frame_writer_mock.reset_mock()
 
             on_open_mock = Mock()
+            assert conn._used_channel_ids == array('H')
             ch = conn.channel(channel_id=channel_id, callback=on_open_mock)
             on_open_mock.assert_called_once_with(ch)
             assert ch.is_open is True
+            assert conn._used_channel_ids == array('H', (1,))
 
             ch.close()
             frame_writer_mock.assert_has_calls(
@@ -552,6 +555,7 @@ class test_channel:
                 ]
             )
             assert ch.is_open is False
+            assert conn._used_channel_ids == array('H')
 
     def test_received_channel_Close_during_connection_close(self):
         # This test verifies that library handles correctly closing channel

--- a/t/unit/test_connection.py
+++ b/t/unit/test_connection.py
@@ -352,8 +352,10 @@ class test_Connection:
         assert self.conn._get_free_channel_id() == 1
         assert self.conn._get_free_channel_id() == 2
 
-    def test_get_free_channel_id__raises_IndexError(self):
-        self.conn._used_channel_ids = array('H', range(1, self.conn.channel_max))
+    def test_get_free_channel_id__raises_ResourceError(self):
+        self.conn.channel_max = 2
+        self.conn._get_free_channel_id()
+        self.conn._get_free_channel_id()
         with pytest.raises(ResourceError):
             self.conn._get_free_channel_id()
 


### PR DESCRIPTION
This PR fixes a performance issue introduced by #377.

I noticed while running tests that `_get_free_channel_id` is way slower than I expected.

Surprisingly, this code that's similar to `_get_free_channel_id` (when all the channel ids are used) takes almost 40 seconds to run:
```
import time
from array import array

channel_max = 65535
used_channel_ids = array('H', range(1, channel_max + 1))
start = time.time()
for channel_id in range(1, channel_max + 1):
    if channel_id not in used_channel_ids:
        assert False
print(f'finished {time.time() - start:0.3f}')
```

This PR casts `_used_channel_ids` to a `set` before the loop, and it only takes ~0.004 seconds to run the loop after this change. It also allows keeping the memory usage improvements by keeping the `_used_channel_ids` stored as an array on the class.

I also learned that there's a bug preventing `_get_free_channel_id` from reaching the `channel_max` (the limit is currently channel_max - 1), and I fixed that too.