### PR TITLE
Set an explicit timeout on SSL handshake to prevent hangs

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -401,6 +401,8 @@ class SSLTransport(_AbstractTransport):
     def _setup_transport(self):
         """Wrap the socket in an SSL object."""
         self.sock = self._wrap_socket(self.sock, **self.sslopts)
+        # Explicitly set a timeout here to stop any hangs on handshake.
+        self.sock.settimeout(self.connect_timeout)
         self.sock.do_handshake()
         self._quick_recv = self.sock.read
 

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -864,6 +864,14 @@ class test_SSLTransport:
         with pytest.raises(socket.timeout):
             self.t._read(64)
 
+    def test_handshake_timeout(self):
+        self.t.sock = Mock()
+        self.t._wrap_socket = Mock()
+        self.t._wrap_socket.return_value = self.t.sock
+        self.t.sock.do_handshake.side_effect = socket.timeout()
+        with pytest.raises(socket.timeout):
+            self.t._setup_transport()
+
 
 class test_TCPTransport:
     class Transport(transport.TCPTransport):


### PR DESCRIPTION
If we do not set a timeout on the SSL handshake, this can cause an infinite hang if something happens during this point to the remote end - this has been seen with AWS MQ RabbitMQ during cluster maintenance triggering a reboot, and causing hangs of any connection that is in the handshake phase.