### PR TITLE
Switch references to the master branch to main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '16 4 * * 1'
 

--- a/README.rst
+++ b/README.rst
@@ -180,12 +180,12 @@ Further
 
     http://www.rabbitmq.com/devtools.html#python-dev
 
-.. |build-status| image:: https://api.travis-ci.com/celery/py-amqp.png?branch=master
+.. |build-status| image:: https://github.com/celery/py-amqp/actions/workflows/ci.yaml/badge.svg
     :alt: Build status
-    :target: https://travis-ci.com/celery/py-amqp
+    :target: https://github.com/celery/py-amqp/actions/workflows/ci.yaml
 
-.. |coverage| image:: https://codecov.io/github/celery/py-amqp/coverage.svg?branch=master
-    :target: https://codecov.io/github/celery/py-amqp?branch=master
+.. |coverage| image:: https://codecov.io/github/celery/py-amqp/coverage.svg?branch=main
+    :target: https://codecov.io/github/celery/py-amqp?branch=main
 
 .. |license| image:: https://img.shields.io/pypi/l/amqp.svg
     :alt: BSD License
@@ -202,7 +202,7 @@ Further
 .. |pyimp| image:: https://img.shields.io/pypi/implementation/amqp.svg
     :alt: Support Python implementations.
     :target: https://pypi.org/project/amqp/
-    
+
 py-amqp as part of the Tidelift Subscription
 ============================================
 

--- a/docs/templates/readme.txt
+++ b/docs/templates/readme.txt
@@ -6,12 +6,12 @@
 
 .. include:: ../includes/introduction.txt
 
-.. |build-status| image:: https://secure.travis-ci.org/celery/py-amqp.png?branch=master
+.. |build-status| image:: https://github.com/celery/py-amqp/actions/workflows/ci.yaml/badge.svg
     :alt: Build status
-    :target: https://travis-ci.org/celery/py-amqp
+    :target: https://github.com/celery/py-amqp/actions/workflows/ci.yaml
 
-.. |coverage| image:: https://codecov.io/github/celery/py-amqp/coverage.svg?branch=master
-    :target: https://codecov.io/github/celery/py-amqp?branch=master
+.. |coverage| image:: https://codecov.io/github/celery/py-amqp/coverage.svg?branch=main
+    :target: https://codecov.io/github/celery/py-amqp?branch=main
 
 .. |license| image:: https://img.shields.io/pypi/l/amqp.svg
     :alt: BSD License


### PR DESCRIPTION
This PR changes the remains of the references to master that we didn't change yet to main.

I also noticed our build status still refers to Travis which is now not in use anymore so we now use the correct badge from Github Actions.