### PR TITLE
Send heartbeat frames more often

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -724,12 +724,17 @@ class Connection(AbstractChannel):
             once per second.
 
         Keyword Arguments:
-            rate (int): Previously used, but ignored now.
+            rate (int): Number of heartbeat frames to send during the heartbeat
+                        timeout
         """
         AMQP_HEARTBEAT_LOGGER.debug('heartbeat_tick : for connection %s',
                                     self._connection_id)
         if not self.heartbeat:
             return
+
+        # If rate is wrong, let's use 2 as default
+        if rate <= 0:
+            rate = 2
 
         # treat actual data exchange in either direction as a heartbeat
         sent_now = self.bytes_sent
@@ -755,7 +760,7 @@ class Connection(AbstractChannel):
         self.prev_sent, self.prev_recv = sent_now, recv_now
 
         # send a heartbeat if it's time to do so
-        if now > self.last_heartbeat_sent + self.heartbeat:
+        if now > self.last_heartbeat_sent + self.heartbeat / rate:
             AMQP_HEARTBEAT_LOGGER.debug(
                 'heartbeat_tick: sending heartbeat for connection %s',
                 self._connection_id)

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps=
 sitepackages = False
 recreate = False
 commands =
-    unit: py.test -xv --cov=amqp --cov-report=xml --no-cov-on-fail t/unit
+    unit: py.test -xv --cov=amqp --cov-report=xml --no-cov-on-fail t/unit {posargs}
     integration: py.test -xv -E rabbitmq t/integration {posargs:-n2}
 basepython =
     flake8,apicheck,linkcheck,pydocstyle: python3.8


### PR DESCRIPTION
The AMQP protocol is saying that we should send "two" "heartbeat frames" during the "heartbeat timeout" (see [1] and rabbit implement this in [2]).

The "two" value is the "rate" parameter in the current implementation.

The current implementation was sending only one frame during the "heartbeat timeout", which is wrong.

[1] https://www.amqp.org/specification/0-9-1/amqp-org-download
[2] https://www.rabbitmq.com/heartbeats.html#heartbeats-interval