### PR TITLE
Add MessageNacked to recoverable errors

### DIFF
--- a/amqp/connection.py
+++ b/amqp/connection.py
@@ -14,7 +14,7 @@ from . import __version__, sasl, spec
 from .abstract_channel import AbstractChannel
 from .channel import Channel
 from .exceptions import (AMQPDeprecationWarning, ChannelError, ConnectionError,
-                         ConnectionForced, RecoverableChannelError,
+                         ConnectionForced, MessageNacked, RecoverableChannelError,
                          RecoverableConnectionError, ResourceError,
                          error_for_code)
 from .method_framing import frame_handler, frame_writer
@@ -179,6 +179,7 @@ class Connection(AbstractChannel):
     channel_errors = (ChannelError,)
     recoverable_connection_errors = (
         RecoverableConnectionError,
+        MessageNacked,
         socket.error,
         IOError,
         OSError,


### PR DESCRIPTION
When the broker is answering with a MessageNacked, we can safely retry.


Change-Id: Ica162f29e855637f5677b08f8452dcce879a5056