### PR TITLE
fix AbstractTransport repr socket error (#361)

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -116,7 +116,10 @@ class _AbstractTransport:
     def __repr__(self):
         if self.sock:
             src = f'{self.sock.getsockname()[0]}:{self.sock.getsockname()[1]}'
-            dst = f'{self.sock.getpeername()[0]}:{self.sock.getpeername()[1]}'
+            try:
+                dst = f'{self.sock.getpeername()[0]}:{self.sock.getpeername()[1]}'
+            except (socket.error) as e:
+                dst = f'ERROR: {e}'
             return f'<{type(self).__name__}: {src} -> {dst} at {id(self):#x}>'
         else:
             return f'<{type(self).__name__}: (disconnected) at {id(self):#x}>'


### PR DESCRIPTION
If AbstractTransport's self.sock is disconnected, then self.sock.getpeername() will raise an error in __repr__, which shows up in backtraces for other upstream errors.

Fix this by catching socket.error in __repr__ and putting the error info in to the returned repr string.

Fixes #361