### PR TITLE
Hard-code requests version because of the bug in docker-py

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ envlist =
     flake8
     apicheck
     pydocstyle
-requires = tox-docker>=2.0
+requires =
+    tox-docker<=4.1
+    requests<=2.31.0
 
 [testenv]
 deps=


### PR DESCRIPTION
Due to [bug reported in decker-py](https://github.com/docker/docker-py/issues/3256) there is a need to hard-code the requests version to <=2.31.0.
5 days ago they released the newest version and the integration tests started failures that day.