### PR TITLE
Update supported python versions in classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,12 @@ classes = """
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     License :: OSI Approved :: BSD License
@@ -132,7 +134,7 @@ setuptools.setup(
     platforms=['any'],
     license='BSD',
     classifiers=classifiers,
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     install_requires=reqs('default.txt'),
     setup_requires=setup_requires,
     tests_require=reqs('test.txt'),


### PR DESCRIPTION
... according to what are actually tested. Also bump the enforced minimum python version to make sure a tested version is used.