### PR TITLE
Add null check for connection to prevent AttributeError on drain_events

### DIFF
--- a/amqp/abstract_channel.py
+++ b/amqp/abstract_channel.py
@@ -96,7 +96,10 @@ class AbstractChannel:
 
         try:
             while not p.ready:
-                self.connection.drain_events(timeout=timeout)
+                conn = self.connection
+                if conn is None:
+                    raise RecoverableConnectionError('Connection already closed')
+                conn.drain_events(timeout=timeout)
 
             if p.value:
                 args, kwargs = p.value

--- a/amqp/abstract_channel.py
+++ b/amqp/abstract_channel.py
@@ -98,7 +98,7 @@ class AbstractChannel:
             while not p.ready:
                 conn = self.connection
                 if conn is None:
-                    raise RecoverableConnectionError('Connection already closed')
+                    raise RecoverableConnectionError('connection already closed')
                 conn.drain_events(timeout=timeout)
 
             if p.value:

--- a/t/unit/test_abstract_channel.py
+++ b/t/unit/test_abstract_channel.py
@@ -83,6 +83,13 @@ class test_AbstractChannel:
             self.c.wait([(50, 61)])
             assert self.c._pending[(50, 61)] is prev
 
+    def test_wait__no_connection(self):
+        self.c.connection = None
+        with pytest.raises(RecoverableConnectionError,
+                           match='Connection already closed'):
+            self.c.wait((50, 61))
+        assert (50, 61) not in self.c._pending
+
     def test_dispatch_method__content_encoding(self):
         self.c.auto_decode = True
         self.method.args = None

--- a/t/unit/test_abstract_channel.py
+++ b/t/unit/test_abstract_channel.py
@@ -86,7 +86,7 @@ class test_AbstractChannel:
     def test_wait__no_connection(self):
         self.c.connection = None
         with pytest.raises(RecoverableConnectionError,
-                           match='Connection already closed'):
+                           match='connection already closed'):
             self.c.wait((50, 61))
         assert (50, 61) not in self.c._pending
 


### PR DESCRIPTION
While null checks exist elsewhere, this specific call was overlooked. This aligns with existing error handling patterns in the codebase.

- reslove #456 