### PR TITLE
Fix prevent channel revival during intentional close to fix shutdown crash

### DIFF
--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -288,7 +288,7 @@ class Channel(AbstractChannel):
                 is the ID of the method.
         """
         self.send_method(spec.Channel.CloseOk)
-        if not self.connection.is_closing:
+        if not self.connection.is_closing and not self.is_closing:
             self._do_revive()
             raise error_for_code(
                 reply_code, reply_text, (class_id, method_id), ChannelError,

--- a/t/unit/test_channel.py
+++ b/t/unit/test_channel.py
@@ -100,7 +100,8 @@ class test_Channel:
     def test_on_close_when_channel_is_closing(self):
         self.c._do_revive = Mock(name='_do_revive')
         self.c.is_closing = True
-        self.c._on_close(404, 'text', 50, 61)
+        with pytest.raises(NotFound):
+            self.c._on_close(404, 'text', 50, 61)
         self.c.send_method.assert_called_with(spec.Channel.CloseOk)
         self.c._do_revive.assert_not_called()
 

--- a/t/unit/test_channel.py
+++ b/t/unit/test_channel.py
@@ -97,6 +97,20 @@ class test_Channel:
         self.c.send_method.assert_called_with(spec.Channel.CloseOk)
         self.c._do_revive.assert_called_with()
 
+    def test_on_close_when_channel_is_closing(self):
+        self.c._do_revive = Mock(name='_do_revive')
+        self.c.is_closing = True
+        self.c._on_close(404, 'text', 50, 61)
+        self.c.send_method.assert_called_with(spec.Channel.CloseOk)
+        self.c._do_revive.assert_not_called()
+
+    def test_on_close_when_connection_is_closing(self):
+        self.c._do_revive = Mock(name='_do_revive')
+        self.conn.is_closing = True
+        self.c._on_close(404, 'text', 50, 61)
+        self.c.send_method.assert_called_with(spec.Channel.CloseOk)
+        self.c._do_revive.assert_not_called()
+
     def test_on_close_ok(self):
         self.c.collect = Mock(name='collect')
         self.c._on_close_ok()

--- a/t/unit/test_channel.py
+++ b/t/unit/test_channel.py
@@ -90,27 +90,22 @@ class test_Channel:
         assert self.c.is_closing is False
         assert self.c.connection is None
 
-    def test_on_close(self):
+    @pytest.mark.parametrize(
+        "channel_is_closing, connection_is_closing, expect_error",
+        [(False, False, True), (True, False, False), (False, True, False)],
+    )
+    def test_on_close(self, channel_is_closing, connection_is_closing, expect_error):
         self.c._do_revive = Mock(name='_do_revive')
-        with pytest.raises(NotFound):
+        self.c.is_closing = channel_is_closing
+        self.conn.is_closing = connection_is_closing
+        if expect_error:
+            with pytest.raises(NotFound):
+                self.c._on_close(404, 'text', 50, 61)
+            self.c._do_revive.assert_called_with()
+        else:
             self.c._on_close(404, 'text', 50, 61)
+            self.c._do_revive.assert_not_called()
         self.c.send_method.assert_called_with(spec.Channel.CloseOk)
-        self.c._do_revive.assert_called_with()
-
-    def test_on_close_when_channel_is_closing(self):
-        self.c._do_revive = Mock(name='_do_revive')
-        self.c.is_closing = True
-        with pytest.raises(NotFound):
-            self.c._on_close(404, 'text', 50, 61)
-        self.c.send_method.assert_called_with(spec.Channel.CloseOk)
-        self.c._do_revive.assert_not_called()
-
-    def test_on_close_when_connection_is_closing(self):
-        self.c._do_revive = Mock(name='_do_revive')
-        self.conn.is_closing = True
-        self.c._on_close(404, 'text', 50, 61)
-        self.c.send_method.assert_called_with(spec.Channel.CloseOk)
-        self.c._do_revive.assert_not_called()
 
     def test_on_close_ok(self):
         self.c.collect = Mock(name='collect')


### PR DESCRIPTION
## Description
This PR addresses the root cause of the `AttributeError: 'NoneType' object has no attribute 'drain_events'` during worker shutdown, as reported in #456.

While #457 adds a defensive null check in the `wait()` loop, this PR fixes the underlying state machine issue where an actively closing channel erroneously attempts to auto-recover itself.

## Root Cause
During a graceful shutdown:

channel.close() is called, which explicitly sets `self.is_closing = True`.

While waiting for the `Channel.CloseOk` frame, the `_on_close` callback might be triggered.

Inside `_on_close`, the guard condition only checked if the connection was closing (`self.connection.is_closing`), but completely ignored the channel's own closing state (`self.is_closing`).

As a result, the channel misinterpreted the intentional shutdown as an unexpected drop and called `_do_revive()`, which eventually crashed when it tried to call `drain_events()` on a destroyed connection.

Proposed Changes
Updated the guard in `amqp/channel.py` -> `_on_close()` to check the channel's local state:

```python
# amqp/channel.py
- if not self.connection.is_closing:
+ if not self.connection.is_closing and not self.is_closing:
      self._do_revive()
By adding not self.is_closing, we ensure that if the channel is already in the process of an intentional shutdown, it will gracefully skip the _do_revive() auto-recovery sequence.
```

Related Issues
- Fixes #456
- Alternative/Complementary to #457 (This fixes the root cause, while #457 acts as a defensive safeguard).