### PR TITLE
ci: Drop the archived GitHub Action useblacksmith/setup-python

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
         id: python
-        uses: useblacksmith/setup-python@v6
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -34,7 +34,7 @@ jobs:
         run: docker build -t rabbitmq:tls .
       - name: Set up Python ${{ matrix.python-version }}
         id: python
-        uses: useblacksmith/setup-python@v6
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
         id: python
-        uses: useblacksmith/setup-python@v6
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
Like:
* celery/django-celery-beat#1062

As recommended in the ***archive notice*** for the GitHub Action `useblacksmith/setup-python`:
* https://github.com/useblacksmith/setup-python#%EF%B8%8F-archive-notice
> Blacksmith now supports transparent caching as explained in https://www.blacksmith.sh/blog/cache. To this effect, it is recommended to switch to the upstream, maintained versions of this action, as you will continue to leverage our much faster caching without any code changes. This action will no longer receive dependency or security updates.