### PR TITLE
Support limiting tls version

### DIFF
--- a/amqp/transport.py
+++ b/amqp/transport.py
@@ -443,7 +443,8 @@ class SSLTransport(_AbstractTransport):
                          server_side=False, cert_reqs=None,
                          ca_certs=None, do_handshake_on_connect=False,
                          suppress_ragged_eofs=True, server_hostname=None,
-                         ciphers=None, ssl_version=None):
+                         ciphers=None, ssl_version=None,
+                         tls_maximum_version=None, tls_minimum_version=None):
         """Socket wrap with SNI headers.
 
         stdlib :attr:`ssl.SSLContext.wrap_socket` method augmented with support
@@ -505,6 +506,17 @@ class SSLTransport(_AbstractTransport):
 
                 Protocol of the SSL Context. The value is one of
                 ``ssl.PROTOCOL_*`` constants.
+
+            tls_maximum_version:
+
+                The highest supported TLS version. The value is a member of
+                ``ssl.TLSVersion``.
+
+            tls_minimum_version:
+
+                The lowest supported TLS version. The value is a member of
+                ``ssl.TLSVersion``.
+
         """
         opts = {
             'sock': sock,
@@ -522,6 +534,10 @@ class SSLTransport(_AbstractTransport):
             )
 
         context = ssl.SSLContext(ssl_version)
+        if tls_maximum_version is not None:
+            context.maximum_version = tls_maximum_version
+        if tls_minimum_version is not None:
+            context.minimum_version = tls_minimum_version
 
         if certfile is not None:
             context.load_cert_chain(certfile, keyfile)

--- a/t/unit/test_transport.py
+++ b/t/unit/test_transport.py
@@ -696,6 +696,26 @@ class test_SSLTransport:
 
             set_ciphers_method_mock.assert_called_with(sentinel.CIPHERS)
 
+    def test_wrap_socket_tls_minimum_version(self):
+        # testing _wrap_socket_sni() with parameter tls_minimum_version
+        with patch('ssl.SSLContext') as mock_ssl_context_class:
+            sock = Mock()
+            context = mock_ssl_context_class()
+            self.t._wrap_socket_sni(
+                sock, tls_minimum_version=ssl.TLSVersion.TLSv1_3
+            )
+            assert context.minimum_version == ssl.TLSVersion.TLSv1_3
+
+    def test_wrap_socket_tls_maximum_version(self):
+        # testing _wrap_socket_sni() with parameter tls_maximum_version
+        with patch('ssl.SSLContext') as mock_ssl_context_class:
+            sock = Mock()
+            context = mock_ssl_context_class()
+            self.t._wrap_socket_sni(
+                sock, tls_maximum_version=ssl.TLSVersion.TLSv1_3
+            )
+            assert context.maximum_version == ssl.TLSVersion.TLSv1_3
+
     def test_wrap_socket_sni_cert_reqs(self):
         with patch('ssl.SSLContext') as mock_ssl_context_class:
             sock = Mock()


### PR DESCRIPTION
The SSLContext object provides a few properties to limit supported TLS versions. Add new options to set these.