### PR TITLE
Treat basic_publish write timeouts as connection errors

### DIFF
--- a/amqp/channel.py
+++ b/amqp/channel.py
@@ -11,7 +11,7 @@ from vine import ensure_promise
 from . import spec
 from .abstract_channel import AbstractChannel
 from .exceptions import (ChannelError, ConsumerCancelled, MessageNacked,
-                         RecoverableChannelError, RecoverableConnectionError,
+                         RecoverableConnectionError,
                          error_for_code)
 from .protocol import queue_declare_ok_t
 
@@ -1798,8 +1798,11 @@ class Channel(AbstractChannel):
                     spec.Basic.Publish, argsig,
                     (0, exchange, routing_key, mandatory, immediate), msg
                 )
-        except socket.timeout:
-            raise RecoverableChannelError('basic_publish: timed out')
+        except (socket.timeout, TimeoutError):
+            # A write timeout means the socket is dead. Channel errors do
+            # not trigger Kombu/ensure() reconnects, so this must be a
+            # connection error. See celery/py-amqp#452.
+            raise RecoverableConnectionError('basic_publish: timed out')
 
     basic_publish = _basic_publish
 

--- a/t/unit/test_channel.py
+++ b/t/unit/test_channel.py
@@ -402,9 +402,10 @@ class test_Channel:
             (0, 'ex', 'rkey', False, False), 'msg',
         )
 
-    def test_basic_publish_timeout_is_connection_error(self):
+    @pytest.mark.parametrize('exc_type', [socket.timeout, TimeoutError])
+    def test_basic_publish_timeout_is_connection_error(self, exc_type):
         self.c.connection.transport.having_timeout = ContextMock()
-        self.c.send_method.side_effect = socket.timeout
+        self.c.send_method.side_effect = exc_type
         with pytest.raises(RecoverableConnectionError, match='timed out'):
             self.c._basic_publish('msg', 'ex', 'rkey')
 

--- a/t/unit/test_channel.py
+++ b/t/unit/test_channel.py
@@ -402,6 +402,12 @@ class test_Channel:
             (0, 'ex', 'rkey', False, False), 'msg',
         )
 
+    def test_basic_publish_timeout_is_connection_error(self):
+        self.c.connection.transport.having_timeout = ContextMock()
+        self.c.send_method.side_effect = socket.timeout
+        with pytest.raises(RecoverableConnectionError, match='timed out'):
+            self.c._basic_publish('msg', 'ex', 'rkey')
+
     def test_basic_publish_confirm(self):
         self.c._confirm_selected = False
         self.c.confirm_select = Mock(name='confirm_select')


### PR DESCRIPTION
Closes #452.

A socket or SSL write timeout during `basic_publish` was wrapped as `RecoverableChannelError`. Kombu `ensure()` does not reconnect on channel errors, so `max_retries` burned through a dead connection.

The socket is dead, so this is a `RecoverableConnectionError`.
