### PR TITLE
Decode AMQP field-table type l as signed 64-bit

### DIFF
--- a/amqp/serialization.py
+++ b/amqp/serialization.py
@@ -80,13 +80,16 @@ def _read_item(buf, offset):
     elif ftype == 'i':
         val, = unpack_from('>I', buf, offset)
         offset += 4
-    # 'L': long long int
+    # 'L': long long int (Qpid unsigned 64-bit uses this letter in some
+    # stacks; py-amqp historically wrote signed 64-bit values as 'L')
     elif ftype == 'L':
         val, = unpack_from('>q', buf, offset)
         offset += 8
-    # 'l': long long unsigned int
+    # 'l': RabbitMQ 64-bit signed int (AMQP 0-9-1 long-long-int).
+    # Decoding as unsigned turned delayed-exchange x-delay=-1000 into
+    # 18446744073709550616. See celery/py-amqp#438.
     elif ftype == 'l':
-        val, = unpack_from('>Q', buf, offset)
+        val, = unpack_from('>q', buf, offset)
         offset += 8
     # 'f': float
     elif ftype == 'f':

--- a/t/unit/test_serialization.py
+++ b/t/unit/test_serialization.py
@@ -32,7 +32,8 @@ class test_serialization:
         ('u', b'u' + pack('>H', 321), 321, None),
         ('i', b'i' + pack('>I', 1234), 1234, None),
         ('L', b'L' + pack('>q', -32451), -32451, None),
-        ('l', b'l' + pack('>Q', 32451), 32451, None),
+        ('l', b'l' + pack('>q', 32451), 32451, None),
+        ('l-neg', b'l' + pack('>q', -1000), -1000, None),
         ('f', b'f' + pack('>f', 33.3), 34.0, ceil),
     ])
     def test_read_item(self, descr, frame, expected, cast):


### PR DESCRIPTION
Closes #438.

RabbitMQ's delayed-message plugin sends `x-delay` as a signed 64-bit field with type `l`. We unpacked that as unsigned, so `-1000` became `18446744073709550616`.

Type `l` is now decoded with `>q`. py-amqp still writes large ints as type `L`, so existing roundtrips stay the same.
