### PR TITLE
Serialize frame_writer() writes with a lock

### DIFF
--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -3,6 +3,7 @@
 
 from collections import defaultdict
 from struct import pack, pack_into, unpack_from
+from threading import Lock
 
 from . import spec
 from .basic_message import Message
@@ -108,7 +109,17 @@ def frame_writer(connection, transport,
 
     buffer_store = Buffer(bytearray(connection.frame_max - 8))
 
+    # The buffer is shared by every frame written on this connection and is
+    # handed to transport.write() as a live memoryview, so two threads
+    # publishing on the same connection would overwrite each other's frame
+    # before the socket has consumed it (#462).
+    buffer_lock = Lock()
+
     def write_frame(type_, channel, method_sig, args, content):
+        with buffer_lock:
+            return _write_frame(type_, channel, method_sig, args, content)
+
+    def _write_frame(type_, channel, method_sig, args, content):
         chunk_size = connection.frame_max - 8
         offset = 0
         properties = None

--- a/amqp/method_framing.py
+++ b/amqp/method_framing.py
@@ -1,9 +1,9 @@
 """Convert between frames and higher-level AMQP methods."""
 # Copyright (C) 2007-2008 Barry Pederson <bp@barryp.org>
 
+import threading
 from collections import defaultdict
 from struct import pack, pack_into, unpack_from
-from threading import Lock
 
 from . import spec
 from .basic_message import Message
@@ -112,8 +112,10 @@ def frame_writer(connection, transport,
     # The buffer is shared by every frame written on this connection and is
     # handed to transport.write() as a live memoryview, so two threads
     # publishing on the same connection would overwrite each other's frame
-    # before the socket has consumed it (#462).
-    buffer_lock = Lock()
+    # before the socket has consumed it (#462).  Looked up at connect time
+    # rather than import time so it picks up eventlet/gevent monkeypatching
+    # even when amqp was imported before the patch was applied.
+    buffer_lock = threading.Lock()
 
     def write_frame(type_, channel, method_sig, args, content):
         with buffer_lock:

--- a/t/unit/test_method_framing.py
+++ b/t/unit/test_method_framing.py
@@ -187,7 +187,7 @@ class test_frame_writer:
         writer_b.start()
         try:
             writer_b.join(0.2)
-            # B must be blocked on the buffer while A's write is in flight.
+            # B must not reach the transport while A's write is in flight.
             assert writer_b.is_alive()
             assert self.transport.write.call_count == 1
         finally:

--- a/t/unit/test_method_framing.py
+++ b/t/unit/test_method_framing.py
@@ -183,9 +183,18 @@ class test_frame_writer:
         writer_a.start()
         assert in_write.wait(2)
 
-        writer_b = threading.Thread(target=self.g, args=frame_b)
+        b_started = threading.Event()
+
+        def write_b():
+            b_started.set()
+            self.g(*frame_b)
+
+        writer_b = threading.Thread(target=write_b)
         writer_b.start()
         try:
+            # Only check once B is actually running, so a slow scheduler
+            # can't make this pass on an unlocked implementation.
+            assert b_started.wait(2)
             writer_b.join(0.2)
             # B must not reach the transport while A's write is in flight.
             assert writer_b.is_alive()

--- a/t/unit/test_method_framing.py
+++ b/t/unit/test_method_framing.py
@@ -1,3 +1,4 @@
+import threading
 from struct import pack
 from unittest.mock import Mock
 
@@ -159,3 +160,41 @@ class test_frame_writer:
         write_arg = self.write.call_args[0][0]
         assert isinstance(write_arg, memoryview)
         assert len(write_arg) > original_frame_max
+
+    def test_write_frame__concurrent_writers_are_serialized(self):
+        """A second thread must not touch the shared buffer while a write
+        is in flight (#462)."""
+        in_write = threading.Event()
+        release_write = threading.Event()
+        seen = []
+
+        def blocking_write(view):
+            # Snapshot what the socket would send *after* it has consumed
+            # the view; another writer must not be able to change it.
+            in_write.set()
+            release_write.wait(2)
+            seen.append(bytes(view))
+
+        self.transport.write.side_effect = blocking_write
+        frame_a = 2, 1, spec.Basic.Publish, b'x' * 10, Message(body=b'A' * 40)
+        frame_b = 2, 1, spec.Basic.Publish, b'x' * 10, Message(body=b'B' * 40)
+
+        writer_a = threading.Thread(target=self.g, args=frame_a)
+        writer_a.start()
+        assert in_write.wait(2)
+
+        writer_b = threading.Thread(target=self.g, args=frame_b)
+        writer_b.start()
+        try:
+            writer_b.join(0.2)
+            # B must be blocked on the buffer while A's write is in flight.
+            assert writer_b.is_alive()
+            assert self.transport.write.call_count == 1
+        finally:
+            release_write.set()
+            writer_a.join(2)
+            writer_b.join(2)
+        assert not writer_a.is_alive() and not writer_b.is_alive()
+        assert self.transport.write.call_count == 2
+        assert b'A' * 40 in seen[0] and b'B' * 40 not in seen[0]
+        assert b'B' * 40 in seen[1] and b'A' * 40 not in seen[1]


### PR DESCRIPTION
Closes celery/py-amqp#462.

`frame_writer()` keeps one `bytearray` per connection and hands `transport.write()` a live `memoryview` of it. Nothing serializes callers, so when two threads publish on the same connection the second `pack_into()` overwrites the buffer while the first write is still draining it, and the socket sends a frame whose length prefix belongs to one message and whose bytes belong to another. No exception — the broker just sees a corrupt frame.

When does this actually happen? Not on the common paths: a prefork celery worker sends heartbeats from the same event-loop thread that publishes, and `task.delay()` goes through `producer_pool`, which hands each thread its own connection. It does happen with the eventlet/gevent pools, where the heartbeat timer runs on its own green thread and yields inside socket I/O (that's where today's `ConcurrentObjectUseError` comes from), and in application code that keeps one `Connection` and drives it from several threads — nothing in py-amqp or kombu says not to, and what you get is a corrupt frame rather than an error.

This isn't limited to SSL. `TCPTransport` uses `socket.sendall`, which takes the buffer by reference (`y*`), then loops `send()` with the GIL released and advances `buf += n`; a `pack_into()` from another thread between two `send()` calls lands in the bytes that haven't gone out yet (resizing the bytearray is blocked by the exported buffer, writing into it isn't). `SSLTransport._write()` has the same window in Python.

Measured on localhost with two threads publishing 60 KB bodies through one `frame_writer()` over a real TCP socket, with the receiver slowed down so `send()` blocks: **79 of 795 body frames** arrived containing the other thread's bytes.

This wraps `write_frame()` in a `threading.Lock`. Alternatives considered on the same setup:

| | corrupted frames | single-thread throughput (60 KB frames) |
|---|---|---|
| current | 79 / 795 | 56.7k frames/s |
| **`Lock` around `write_frame()`** | **0** / 800 | 59.4k (within noise) |
| `write(bytes(view))` — copy per frame | 0 / 796 | 48.9k (−16%) |

The lock is uncontended on the single-threaded path — about 200 ns per frame with a no-op transport, below noise on a real socket; the copy pays a memcpy per frame, which is what the fast path exists to avoid. The lock is looked up as `threading.Lock()` when the writer is created rather than at import time, so it picks up eventlet/gevent monkeypatching even if `amqp` was imported before the patch was applied (with a raw lock the two-greenlet case would deadlock the hub instead of raising as it does today). Documenting "don't share a connection between threads" would also be true, but the failure here is silent corruption rather than an error, so I'd rather make it safe.

One behaviour change worth stating: a signal handler that writes to the same connection from inside a write (e.g. `SIGTERM` → `connection.close()`) used to corrupt the stream and carry on; with the lock it would block on itself. That was never safe, but it fails differently now.

The test drives two writers from separate threads with the transport's `write()` parked on an `Event`, and asserts the second writer cannot enter until the first write returns and that each write's bytes contain only its own body. It fails on `main` (the second writer runs straight through) and passes here. `t/unit` is otherwise unchanged.
