### PR TITLE
Drop unused python version check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,6 @@ jobs:
         run: |
           CELERY_ENABLE_SPEEDUPS=1 python setup.py develop
           tox -v -e ${{ matrix.python-version }}-integration-rabbitmq -- -v
-        if: ${{ matrix.python-version != 'pypy-3.9'}}
 
   #################### Linters and checkers ####################
   lint:


### PR DESCRIPTION
pypy-3.9 was removed by f778218d788477539cad672ea678081cd7b9ea0a .